### PR TITLE
Tag filter with correct lowercase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255485c2f41cf8f39d4e4a1901199549f54e32def81a71a8afe05f75809f441d"
+checksum = "25e4e34578e8cc2b4050c6224a0c422b23ba1e61f2602b4e320c221ac3cbbc2e"
 dependencies = [
  "aes",
  "base64 0.21.7",

--- a/src/util.rs
+++ b/src/util.rs
@@ -263,11 +263,7 @@ pub async fn get_direct_messages(
 
                 let human_date = date.unwrap().format("%H:%M date - %d/%m/%Y").to_string();
 
-                let message = decrypt(
-                    &my_key.secret_key().unwrap(),
-                    &dm.pubkey,
-                    dm.content.clone(),
-                );
+                let message = decrypt(my_key.secret_key().unwrap(), &dm.pubkey, dm.content.clone());
                 direct_messages.push(((message.unwrap()), (human_date)));
             }
         }
@@ -287,9 +283,9 @@ pub async fn get_orders_list(
 ) -> Result<Vec<SmallOrder>> {
     let generic_filter = Filter::new()
         .author(pubkey)
-        .custom_tag(SingleLetterTag::uppercase(Alphabet::Z), vec!["order"])
+        .custom_tag(SingleLetterTag::lowercase(Alphabet::Z), vec!["order"])
         .custom_tag(
-            SingleLetterTag::uppercase(Alphabet::S),
+            SingleLetterTag::lowercase(Alphabet::S),
             vec![status.to_string()],
         )
         .kind(Kind::Custom(NOSTR_REPLACEABLE_EVENT_KIND));
@@ -299,13 +295,13 @@ pub async fn get_orders_list(
     if let Some(c) = currency {
         exec_filter = exec_filter
             .clone()
-            .custom_tag(SingleLetterTag::uppercase(Alphabet::F), vec![c.to_string()]);
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::F), vec![c.to_string()]);
     }
 
     if let Some(k) = kind {
         exec_filter = exec_filter
             .clone()
-            .custom_tag(SingleLetterTag::uppercase(Alphabet::K), vec![k.to_string()]);
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::K), vec![k.to_string()]);
     }
 
     info!(
@@ -367,9 +363,9 @@ pub async fn get_orders_list(
 pub async fn get_disputes_list(pubkey: PublicKey, client: &Client) -> Result<Vec<Dispute>> {
     let generic_filter = Filter::new()
         .author(pubkey)
-        .custom_tag(SingleLetterTag::uppercase(Alphabet::Z), vec!["dispute"])
+        .custom_tag(SingleLetterTag::lowercase(Alphabet::Z), vec!["dispute"])
         .custom_tag(
-            SingleLetterTag::uppercase(Alphabet::S),
+            SingleLetterTag::lowercase(Alphabet::S),
             vec![DisputeStatus::Initiated.to_string()],
         )
         .kind(Kind::Custom(NOSTR_REPLACEABLE_EVENT_KIND));


### PR DESCRIPTION
Hi @grunch ,

small fix for tag filter with correct lowercase and updated cargo.lock to sdk 0.29.1 to fix tag parse issue.