### PR TITLE
Range order draft idea

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-cli"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 license = "MIT"
 authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ uuid = { version = "1.3.0", features = [
 dotenvy = "0.15.6"
 lightning-invoice = "0.23.0"
 reqwest = { version = "0.12.4", features = ["json"] }
-mostro-core = { version = "0.5.8", features = ["sqlx"] }
+mostro-core = { version = "0.5.9", features = ["sqlx"] }
 bitcoin_hashes = "0.12.0"
 lnurl-rs = "0.4.0"
 pretty_env_logger = "0.5.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -196,11 +196,45 @@ pub enum Commands {
     },
 }
 
-/// Check range simple version for just a single value
-pub fn check_fiat_range(s: &str) -> Result<i64, String> {
-    match s.parse::<i64>() {
-        Ok(val) => Ok(val),
-        Err(_e) => Err(String::from("Error on parsing sats value")),
+// Check range with two values value
+fn check_fiat_range(s: &str) -> Result<String, String> {
+    if s.contains('-') {
+        let min: i64;
+        let max: i64;
+
+        // Get values from CLI
+        let values: Vec<&str> = s.split('-').collect();
+
+        // Check if more than two values
+        if values.len() > 2 {
+            return Err(String::from("Error"));
+        };
+
+        // Get ranged command
+        if let Err(e) = values[0].parse::<i64>() {
+            return Err(e.to_string());
+        } else {
+            min = values[0].parse().unwrap();
+        }
+
+        if let Err(e) = values[1].parse::<i64>() {
+            return Err(e.to_string());
+        } else {
+            max = values[1].parse().unwrap();
+        }
+
+        // Check min below max
+        if min >= max {
+            return Err(String::from(
+                "Range of values must be 100-200 for example...",
+            ));
+        };
+        Ok(s.to_string())
+    } else {
+        match s.parse::<i64>() {
+            Ok(_) => Ok(s.to_string()),
+            Err(e) => Err(e.to_string()),
+        }
     }
 }
 

--- a/src/cli/new_order.rs
+++ b/src/cli/new_order.rs
@@ -17,7 +17,7 @@ pub type FiatNames = HashMap<String, String>;
 pub async fn execute_new_order(
     kind: &str,
     fiat_code: &str,
-    fiat_amount: &i64,
+    fiat_amount: &(i64, Option<i64>),
     amount: &i64,
     payment_method: &String,
     premium: &i64,
@@ -56,6 +56,15 @@ pub async fn execute_new_order(
         }
     };
 
+    // Get the type of neworder
+    // if both tuple field are valid than it's a range order
+    // otherwise use just fiat amount value as before
+    let amt = if fiat_amount.1.is_some() {
+        (0, fiat_amount.0, fiat_amount.1.unwrap())
+    } else {
+        (fiat_amount.0, 0, 0)
+    };
+
     // Create new order for mostro
     let order_content = Content::Order(SmallOrder::new(
         None,
@@ -63,7 +72,9 @@ pub async fn execute_new_order(
         Some(Status::Pending),
         *amount,
         fiat_code,
-        *fiat_amount,
+        amt.1,
+        amt.2,
+        amt.0,
         payment_method.to_owned(),
         *premium,
         None,

--- a/src/pretty_table.rs
+++ b/src/pretty_table.rs
@@ -59,7 +59,13 @@ pub fn print_order_preview(ord: Content) -> Result<String, String> {
             Cell::new(single_order.amount).set_alignment(CellAlignment::Center)
         },
         Cell::new(single_order.fiat_code.to_string()).set_alignment(CellAlignment::Center),
-        Cell::new(single_order.fiat_amount.to_string()).set_alignment(CellAlignment::Center),
+        // No range order print row
+        if single_order.min_amount == 0 && single_order.max_amount == 0 {
+            Cell::new(single_order.fiat_amount.to_string()).set_alignment(CellAlignment::Center)
+        } else {
+            let range_str = format!("{}-{}", single_order.min_amount, single_order.max_amount);
+            Cell::new(range_str).set_alignment(CellAlignment::Center)
+        },
         Cell::new(single_order.payment_method.to_string()).set_alignment(CellAlignment::Center),
         Cell::new(single_order.premium.to_string()).set_alignment(CellAlignment::Center),
     ]);


### PR DESCRIPTION
Hi @grunch ,

first proposal for `ranged orders`.

I used two new variables: `min_amount` and `max_amount` in pair of a tuple use here:
```Rust
    // Get the type of neworder
    // if both tuple field are valid than it's a range order
    // otherwise use just fiat amount value as before
    let amt = if fiat_amount.1.is_some() {
        (0, fiat_amount.0, fiat_amount.1.unwrap())
    } else {
        (fiat_amount.0, 0, 0)
    };
```

and recoverer the old range_check function that was on older commits to parse from CLI the ranged or not neworder:
```Rust
// Check range with two values value
fn check_fiat_range(s: &str) -> Result<(i64, Option<i64>)> {
    if s.contains('-') {
        let min: i64;
        let max: i64;

        // Get values from CLI
        let values: Vec<&str> = s.split('-').collect();

        // Check if more than two values
        if values.len() > 2 {
            return Err(Error::msg("Wrong amount syntax"));
        };

        // Get ranged command
        if let Err(e) = values[0].parse::<i64>() {
            return Err(e.into());
        } else {
            min = values[0].parse().unwrap();
        }

        if let Err(e) = values[1].parse::<i64>() {
            return Err(e.into());
        } else {
            max = values[1].parse().unwrap();
        }

        // Check min below max
        if min >= max {
            return Err(Error::msg("Range of values must be 100-200 for example..."));
        };
        Ok((min, Some(max)))
    } else {
        match s.parse::<i64>() {
            Ok(s) => Ok((s, None)),
            Err(e) => Err(e.into()),
        }
    }
}
```

I did a quick test up to order preview and seems working, please review and let me know.

Will follow work on `mostrod `side.




