### PR TITLE
Shared key print

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,10 @@ use crate::util;
 use anyhow::{Error, Result};
 use clap::{Parser, Subcommand};
 use nostr_sdk::prelude::*;
-use std::env::{set_var, var};
+use std::{
+    env::{set_var, var},
+    str::FromStr,
+};
 use uuid::Uuid;
 
 #[derive(Parser)]
@@ -200,6 +203,12 @@ pub enum Commands {
         #[arg(short, long)]
         dispute_id: Uuid,
     },
+    /// Create a shared key for direct messaging
+    CreateSharedKey {
+        /// Pubkey of receiver
+        #[arg(short, long)]
+        pubkey: String,
+    },
 }
 
 // Check range with two values value
@@ -274,6 +283,18 @@ pub async fn run() -> Result<()> {
 
     if let Some(cmd) = cli.command {
         match &cmd {
+            Commands::CreateSharedKey { pubkey } => {
+                let key = nostr::util::generate_shared_key(
+                    my_key.secret_key()?,
+                    &PublicKey::from_str(&pubkey)?,
+                );
+                let mut shared_key_hex = vec![];
+                for i in key{
+                    shared_key_hex.push(format!("{:0x}",i))
+                }
+                println!("Shared key: {:?}", key);
+                println!("Shared key: {:?}", shared_key_hex);
+            }
             Commands::ListOrders {
                 status,
                 currency,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -205,7 +205,7 @@ pub enum Commands {
     },
     /// Create a shared key for direct messaging
     CreateSharedKey {
-        /// Pubkey of receiver
+        /// Pubkey of receiver of the message
         #[arg(short, long)]
         pubkey: String,
     },


### PR DESCRIPTION
Hi @grunch ,

simple printout of shared key coming from Nostr-sdk.

Example:

`mostro-cli createsharedkey --pubkey eebe78371ba8fe3dd53623aa529df638b9d1b8b7ce9235d6b703c2ee518f41fd`