### PR TITLE
Final code on sending messages

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,9 @@ pub enum Commands {
         #[arg(short, long)]
         #[clap(default_value_t = 30)]
         since: i64,
+        /// If true, get messages from counterparty, otherwise from Mostro
+        #[arg(short)]
+        from_user: bool,
     },
     /// Send direct message to a user
     SendDm {
@@ -223,9 +226,6 @@ pub enum Commands {
         /// Pubkey of the counterpart
         #[arg(short, long)]
         pubkey: String,
-        /// Event id of the message to derive the key
-        #[arg(short, long)]
-        event_id: String,
     },
 }
 
@@ -305,9 +305,8 @@ pub async fn run() -> Result<()> {
 
     if let Some(cmd) = cli.command {
         match &cmd {
-            Commands::ConversationKey { event_id, pubkey } => {
-                execute_conversation_key(&my_key, PublicKey::from_str(pubkey)?, &client, event_id)
-                    .await?
+            Commands::ConversationKey { pubkey } => {
+                execute_conversation_key(&my_key, PublicKey::from_str(pubkey)?).await?
             }
             Commands::ListOrders {
                 status,
@@ -327,7 +326,9 @@ pub async fn run() -> Result<()> {
             Commands::AddInvoice { order_id, invoice } => {
                 execute_add_invoice(order_id, invoice, &my_key, mostro_key, &client).await?
             }
-            Commands::GetDm { since } => execute_get_dm(since, &my_key, &client).await?,
+            Commands::GetDm { since, from_user } => {
+                execute_get_dm(since, &my_key, &client, *from_user).await?
+            }
             Commands::FiatSent { order_id }
             | Commands::Release { order_id }
             | Commands::Dispute { order_id }

--- a/src/cli/add_invoice.rs
+++ b/src/cli/add_invoice.rs
@@ -34,7 +34,7 @@ pub async fn execute_add_invoice(
         .as_json()
         .unwrap();
 
-    send_order_id_cmd(client, my_key, mostro_key, add_invoice_message, true).await?;
+    send_order_id_cmd(client, my_key, mostro_key, add_invoice_message, true, true).await?;
 
     Ok(())
 }

--- a/src/cli/conversation_key.rs
+++ b/src/cli/conversation_key.rs
@@ -1,38 +1,17 @@
 use anyhow::Result;
 use nip44::v2::ConversationKey;
 use nostr_sdk::prelude::*;
-use std::str::FromStr;
 
-use crate::util::send_relays_requests;
-
-pub async fn execute_conversation_key(
-    my_key: &Keys,
-    receiver: PublicKey,
-    client: &Client,
-    event_id: &str,
-) -> Result<()> {
-    let id = EventId::from_str(event_id)?;
-    let filter = Filter::new().id(id).limit(1);
-    let mostro_req = send_relays_requests(client, filter).await;
-    let event = mostro_req.first().unwrap().first().unwrap();
-    // Derive gift wrap conversation key
-    let gw_ck = ConversationKey::derive(my_key.secret_key()?, &event.pubkey);
-    let gw_key = gw_ck.as_bytes();
-    let mut gw_ck_hex = vec![];
-    for i in gw_key {
-        gw_ck_hex.push(format!("{:02x}", i));
+pub async fn execute_conversation_key(my_key: &Keys, receiver: PublicKey) -> Result<()> {
+    // Derive conversation key
+    let ck = ConversationKey::derive(my_key.secret_key()?, &receiver);
+    let key = ck.as_bytes();
+    let mut ck_hex = vec![];
+    for i in key {
+        ck_hex.push(format!("{:02x}", i));
     }
-    let gw_ck_hex = gw_ck_hex.join("");
-    // Derive seal conversation key
-    let seal_ck = ConversationKey::derive(my_key.secret_key()?, &receiver);
-    let seal_key = seal_ck.as_bytes();
-    let mut seal_ck_hex = vec![];
-    for i in seal_key {
-        seal_ck_hex.push(format!("{:02x}", i));
-    }
-    let seal_ck_hex = seal_ck_hex.join("");
-    println!("Gift wrap Conversation key: {:?}", gw_ck_hex);
-    println!("Seal Conversation key: {:?}", seal_ck_hex);
+    let ck_hex = ck_hex.join("");
+    println!("Conversation key: {:?}", ck_hex);
 
     Ok(())
 }

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -4,8 +4,13 @@ use nostr_sdk::prelude::*;
 
 use crate::util::get_direct_messages;
 
-pub async fn execute_get_dm(since: &i64, my_key: &Keys, client: &Client) -> Result<()> {
-    let dm = get_direct_messages(client, my_key, *since).await;
+pub async fn execute_get_dm(
+    since: &i64,
+    my_key: &Keys,
+    client: &Client,
+    from_user: bool,
+) -> Result<()> {
+    let dm = get_direct_messages(client, my_key, *since, from_user).await;
     if dm.is_empty() {
         println!();
         println!("No new messages");

--- a/src/cli/new_order.rs
+++ b/src/cli/new_order.rs
@@ -113,6 +113,6 @@ pub async fn execute_new_order(
         .as_json()
         .unwrap();
 
-    send_order_id_cmd(client, my_key, mostro_key, message, false).await?;
+    send_order_id_cmd(client, my_key, mostro_key, message, false, true).await?;
     Ok(())
 }

--- a/src/cli/rate_user.rs
+++ b/src/cli/rate_user.rs
@@ -28,7 +28,7 @@ pub async fn execute_rate_user(
         .as_json()
         .unwrap();
 
-    send_order_id_cmd(client, my_key, mostro_key, rate_message, true).await?;
+    send_order_id_cmd(client, my_key, mostro_key, rate_message, true, true).await?;
 
     std::process::exit(0);
 }

--- a/src/cli/send_dm.rs
+++ b/src/cli/send_dm.rs
@@ -8,7 +8,7 @@ pub async fn execute_send_dm(
     client: &Client,
     message: &str,
 ) -> Result<()> {
-    send_order_id_cmd(client, my_key, receiver, message.to_string(), true).await?;
+    send_order_id_cmd(client, my_key, receiver, message.to_string(), true, true).await?;
 
     Ok(())
 }

--- a/src/cli/send_msg.rs
+++ b/src/cli/send_msg.rs
@@ -47,7 +47,7 @@ pub async fn execute_send_msg(
         .as_json()
         .unwrap();
     info!("Sending message: {:#?}", message);
-    send_order_id_cmd(client, my_key, mostro_key, message, false).await?;
+    send_order_id_cmd(client, my_key, mostro_key, message, false, true).await?;
 
     Ok(())
 }

--- a/src/cli/take_buy.rs
+++ b/src/cli/take_buy.rs
@@ -26,7 +26,7 @@ pub async fn execute_take_buy(
     .as_json()
     .unwrap();
 
-    send_order_id_cmd(client, my_key, mostro_key, take_buy_message, true).await?;
+    send_order_id_cmd(client, my_key, mostro_key, take_buy_message, true, true).await?;
 
     Ok(())
 }

--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -22,7 +22,7 @@ pub async fn execute_take_dispute(
             .as_json()
             .unwrap();
 
-    send_order_id_cmd(client, my_key, mostro_key, take_dispute_message, true).await?;
+    send_order_id_cmd(client, my_key, mostro_key, take_dispute_message, true, true).await?;
 
     Ok(())
 }

--- a/src/cli/take_sell.rs
+++ b/src/cli/take_sell.rs
@@ -50,6 +50,6 @@ pub async fn execute_take_sell(
         .as_json()
         .unwrap();
 
-    send_order_id_cmd(client, my_key, mostro_key, take_sell_message, true).await?;
+    send_order_id_cmd(client, my_key, mostro_key, take_sell_message, true, true).await?;
     Ok(())
 }


### PR DESCRIPTION
All messages to mostro are being sent using nip59

Messages between parties are simple nostr messages kind 14 encrypted with nip44 between two parties, users should use ephemeral keys to send this messages.
User can get the conversation key of this messages and delivered to an admin in case of a dispute, this way the admin can see the history of the chat between parties