### PR TITLE
Fix: missing order id in take-sell

### DIFF
--- a/src/cli/take_sell.rs
+++ b/src/cli/take_sell.rs
@@ -50,10 +50,15 @@ pub async fn execute_take_sell(
         };
     }
     // Create takesell message
-    let take_sell_message =
-        Message::new_order(None, None, Some(trade_index), Action::TakeSell, payload)
-            .as_json()
-            .unwrap();
+    let take_sell_message = Message::new_order(
+        Some(*order_id),
+        None,
+        Some(trade_index),
+        Action::TakeSell,
+        payload,
+    )
+    .as_json()
+    .unwrap();
 
     send_order_id_cmd(
         client,


### PR DESCRIPTION
Hi @grunch,

starting back to test order cycle, this I think is a missing 'order-id' in take-sell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved order message construction by including `order_id` in the message.
  
- **Chores**
	- Updated method signature for better clarity in asynchronous execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->