### PR TITLE
Fix: sends right index on first operation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -307,6 +307,7 @@ pub async fn run() -> Result<()> {
     let (trade_keys, trade_index) = User::get_next_trade_keys(&pool)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to get trade keys: {}", e))?;
+
     // Mostro pubkey
     let mostro_key = PublicKey::from_str(&pubkey)?;
 

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -85,7 +85,7 @@ pub async fn execute_get_dm(
                             // Update last trade index
                             match User::get(&pool).await {
                                 Ok(mut user) => {
-                                    user.set_last_trade_index(trade_index + 1);
+                                    user.set_last_trade_index(trade_index);
                                     if let Err(e) = user.save(&pool).await {
                                         println!("Failed to update user: {}", e);
                                     }

--- a/src/cli/new_order.rs
+++ b/src/cli/new_order.rs
@@ -182,7 +182,7 @@ pub async fn execute_new_order(
         // Update last trade index
         match User::get(&pool).await {
             Ok(mut user) => {
-                user.set_last_trade_index(trade_index + 1);
+                user.set_last_trade_index(trade_index);
                 if let Err(e) = user.save(&pool).await {
                     println!("Failed to update user: {}", e);
                 }

--- a/src/cli/send_msg.rs
+++ b/src/cli/send_msg.rs
@@ -102,7 +102,7 @@ pub async fn execute_send_msg(
                     // Update last trade index
                     match User::get(&pool).await {
                         Ok(mut user) => {
-                            user.set_last_trade_index(trade_index + 1);
+                            user.set_last_trade_index(trade_index);
                             if let Err(e) = user.save(&pool).await {
                                 println!("Failed to update user: {}", e);
                             }

--- a/src/cli/take_buy.rs
+++ b/src/cli/take_buy.rs
@@ -95,7 +95,7 @@ pub async fn execute_take_buy(
                 // Update last trade index to be used in next trade
                 match User::get(&pool).await {
                     Ok(mut user) => {
-                        user.set_last_trade_index(trade_index + 1);
+                        user.set_last_trade_index(trade_index);
                         if let Err(e) = user.save(&pool).await {
                             println!("Failed to update user: {}", e);
                         }

--- a/src/cli/take_sell.rs
+++ b/src/cli/take_sell.rs
@@ -117,7 +117,7 @@ pub async fn execute_take_sell(
             // Update last trade index to be used in next trade
             match User::get(&pool).await {
                 Ok(mut user) => {
-                    user.set_last_trade_index(trade_index + 1);
+                    user.set_last_trade_index(trade_index);
                     if let Err(e) = user.save(&pool).await {
                         println!("Failed to update user: {}", e);
                     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -170,8 +170,7 @@ impl User {
     }
 
     pub async fn get_next_trade_keys(pool: &SqlitePool) -> Result<(Keys, i64)> {
-        let mut trade_index = User::get_next_trade_index(pool.clone()).await?;
-        trade_index -= 1;
+        let trade_index = User::get_next_trade_index(pool.clone()).await?;
 
         let user = User::get(pool).await?;
         let account = NOSTR_REPLACEABLE_EVENT_KIND as u32;


### PR DESCRIPTION
Fix #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
    - Corrected trade index tracking mechanism across multiple user operations
    - Ensured consistent last trade index recording without unnecessary incrementation

- **Refactor**
    - Simplified trade index management in user-related functions
    - Standardized trade index assignment logic across different command handlers

- **Chores**
    - Updated internal trade key generation process
    - Minor optimization of user data management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->