### PR TITLE
Fixed admin keys send in case of admin dispute commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -158,6 +158,16 @@ pub enum Commands {
         #[arg(short)]
         from_user: bool,
     },
+    /// Get the latest direct messages for admin
+    GetAdminDm {
+        /// Since time of the messages in minutes
+        #[arg(short, long)]
+        #[clap(default_value_t = 30)]
+        since: i64,
+        /// If true, get messages from counterparty, otherwise from Mostro
+        #[arg(short)]
+        from_user: bool,
+    },
     /// Send direct message to a user
     SendDm {
         /// Pubkey of the counterpart
@@ -365,7 +375,10 @@ pub async fn run() -> Result<()> {
                 execute_add_invoice(order_id, invoice, &identity_keys, mostro_key, &client).await?
             }
             Commands::GetDm { since, from_user } => {
-                execute_get_dm(since, trade_index, &client, *from_user).await?
+                execute_get_dm(since, trade_index, &client, *from_user, false).await?
+            }
+            Commands::GetAdminDm { since, from_user } => {
+                execute_get_dm(since, trade_index, &client, *from_user, true).await?
             }
             Commands::FiatSent { order_id }
             | Commands::Release { order_id }

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -13,12 +13,25 @@ pub async fn execute_get_dm(
     trade_index: i64,
     client: &Client,
     from_user: bool,
+    admin: bool,
 ) -> Result<()> {
     let mut dm: Vec<(Message, u64)> = Vec::new();
     let pool = connect().await?;
-    for index in 1..=trade_index {
-        let keys = User::get_trade_keys(&pool, index).await?;
-        let dm_temp = get_direct_messages(client, &keys, *since, from_user).await;
+    if !admin {
+        for index in 1..=trade_index {
+            let keys = User::get_trade_keys(&pool, index).await?;
+            let dm_temp = get_direct_messages(client, &keys, *since, from_user).await;
+            dm.extend(dm_temp);
+        }
+    } else {
+        let id_key = match std::env::var("NSEC_PRIVKEY") {
+            Ok(id_key) => Keys::parse(&id_key)?,
+            Err(e) => {
+                println!("Failed to get mostro admin private key: {}", e);
+                std::process::exit(1);
+            }
+        };
+        let dm_temp = get_direct_messages(client, &id_key, *since, from_user).await;
         dm.extend(dm_temp);
     }
 
@@ -48,6 +61,18 @@ pub async fn execute_get_dm(
                         println!();
                         println!("{text}");
                         println!();
+                    }
+                    Payload::Dispute(id, token, info) => {
+                        println!("Action: {}", message.action);
+                        println!("Dispute id: {}", id);
+                        if token.is_some() {
+                            println!("Dispute token: {}", token.unwrap());
+                        }
+                        if info.is_some() {
+                            println!();
+                            println!("Dispute info: {:#?}", info);
+                            println!();
+                        }
                     }
                     Payload::CantDo(Some(cant_do_reason)) => {
                         println!();

--- a/src/cli/send_dm.rs
+++ b/src/cli/send_dm.rs
@@ -32,7 +32,6 @@ pub async fn execute_send_dm(
         std::process::exit(0)
     };
 
-
     send_message_sync(client, None, &trade_keys, receiver, message, true, true).await?;
 
     Ok(())

--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -5,6 +5,70 @@ use uuid::Uuid;
 
 use crate::util::send_message_sync;
 
+pub async fn execute_admin_cancel_dispute(
+    dispute_id: &Uuid,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_key: PublicKey,
+    client: &Client,
+) -> Result<()> {
+    println!(
+        "Request of cancel dispute {} from mostro pubId {}",
+        dispute_id,
+        mostro_key.clone()
+    );
+    // Create takebuy message
+    let take_dispute_message =
+        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminCancel, None);
+
+    println!("identity_keys: {:?}", identity_keys.public_key.to_string());
+
+    send_message_sync(
+        client,
+        Some(identity_keys),
+        trade_keys,
+        mostro_key,
+        take_dispute_message,
+        true,
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+pub async fn execute_admin_settle_dispute(
+    dispute_id: &Uuid,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_key: PublicKey,
+    client: &Client,
+) -> Result<()> {
+    println!(
+        "Request of take dispute {} from mostro pubId {}",
+        dispute_id,
+        mostro_key.clone()
+    );
+    // Create takebuy message
+    let take_dispute_message =
+        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminSettle, None);
+
+    println!("identity_keys: {:?}", identity_keys.public_key.to_string());
+
+    send_message_sync(
+        client,
+        Some(identity_keys),
+        trade_keys,
+        mostro_key,
+        take_dispute_message,
+        true,
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
 pub async fn execute_take_dispute(
     dispute_id: &Uuid,
     identity_keys: &Keys,
@@ -25,6 +89,8 @@ pub async fn execute_take_dispute(
         Action::AdminTakeDispute,
         None,
     );
+
+    println!("identity_keys: {:?}", identity_keys.public_key.to_string());
 
     send_message_sync(
         client,

--- a/src/util.rs
+++ b/src/util.rs
@@ -200,8 +200,8 @@ pub async fn get_direct_messages(
                     let unencrypted_content = decrypt_to_bytes(&ck, &b64decoded_content)
                         .expect("Failed to decrypt message");
 
-                    let message = String::from_utf8(unencrypted_content)
-                        .expect("Found invalid UTF-8");
+                    let message =
+                        String::from_utf8(unencrypted_content).expect("Found invalid UTF-8");
                     let message = Message::from_json(&message).expect("Failed on deserializing");
 
                     (dm.created_at, message)


### PR DESCRIPTION
@grunch , @Catrya 

this is the complementary fix for `mostro-cli` to have disputes working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new command for retrieving the latest direct messages for admin users.
  - Enhanced administrative commands for settling and canceling disputes with improved key retrieval and error handling.
- **Refactor**
  - Improved command handling logic for administrative actions, ensuring more specific implementations. 
  - Minor formatting adjustments for better readability in message retrieval functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->