### PR TITLE
Feature new command for getdm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.6.28"
+version = "0.6.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc439d283bc64ae1d8b6d7f83994ceec750f402d3e7515c97757ba684271eef4"
+checksum = "2dc562fdc1e062fd9ddca15209a04043fbb45133fe51748c26e0fa9f2778c505"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ uuid = { version = "1.3.0", features = [
 dotenvy = "0.15.6"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
 reqwest = { version = "0.12.4", features = ["json"] }
-mostro-core = "0.6.28"
+mostro-core = "0.6.31"  
 lnurl-rs = "0.9.0"
 pretty_env_logger = "0.5.0"
 openssl = { version = "0.10.68", features = ["vendored"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,15 +389,14 @@ pub async fn run() -> Result<()> {
                 .await?
             }
             Commands::AdmAddSolver { npubkey } => {
-                execute_send_msg(
-                    cmd.clone(),
-                    None,
-                    Some(&identity_keys),
-                    mostro_key,
-                    &client,
-                    Some(npubkey),
-                )
-                .await?
+                let id_key = match std::env::var("NSEC_PRIVKEY") {
+                    Ok(id_key) => Keys::parse(&id_key)?,
+                    Err(e) => {
+                        println!("Failed to get mostro admin private key: {}", e);
+                        std::process::exit(1);
+                    }
+                };
+                execute_admin_add_solver(npubkey, &id_key, &trade_keys, mostro_key, &client).await?
             }
             Commands::NewOrder {
                 kind,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,7 @@ use std::{
     env::{set_var, var},
     str::FromStr,
 };
+use take_dispute::*;
 use uuid::Uuid;
 
 #[derive(Parser)]
@@ -363,8 +364,6 @@ pub async fn run() -> Result<()> {
             Commands::FiatSent { order_id }
             | Commands::Release { order_id }
             | Commands::Dispute { order_id }
-            | Commands::AdmCancel { order_id }
-            | Commands::AdmSettle { order_id }
             | Commands::Cancel { order_id } => {
                 execute_send_msg(
                     cmd.clone(),
@@ -417,9 +416,38 @@ pub async fn run() -> Result<()> {
             Commands::Rate { order_id, rating } => {
                 execute_rate_user(order_id, rating, &identity_keys, mostro_key, &client).await?;
             }
+            Commands::AdmSettle { order_id } => {
+                let id_key = match std::env::var("NSEC_PRIVKEY") {
+                    Ok(id_key) => Keys::parse(&id_key)?,
+                    Err(e) => {
+                        println!("Failed to get mostro admin private key: {}", e);
+                        std::process::exit(1);
+                    }
+                };
+                execute_admin_settle_dispute(order_id, &id_key, &trade_keys, mostro_key, &client)
+                    .await?;
+            }
+            Commands::AdmCancel { order_id } => {
+                let id_key = match std::env::var("NSEC_PRIVKEY") {
+                    Ok(id_key) => Keys::parse(&id_key)?,
+                    Err(e) => {
+                        println!("Failed to get mostro admin private key: {}", e);
+                        std::process::exit(1);
+                    }
+                };
+                execute_admin_cancel_dispute(order_id, &id_key, &trade_keys, mostro_key, &client)
+                    .await?;
+            }
             Commands::AdmTakeDispute { dispute_id } => {
-                execute_take_dispute(dispute_id, &identity_keys, &trade_keys, mostro_key, &client)
-                    .await?
+                let id_key = match std::env::var("NSEC_PRIVKEY") {
+                    Ok(id_key) => Keys::parse(&id_key)?,
+                    Err(e) => {
+                        println!("Failed to get mostro admin private key: {}", e);
+                        std::process::exit(1);
+                    }
+                };
+
+                execute_take_dispute(dispute_id, &id_key, &trade_keys, mostro_key, &client).await?
             }
             Commands::AdmListDisputes {} => execute_list_disputes(mostro_key, &client).await?,
             Commands::SendDm {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,6 +156,16 @@ pub enum Commands {
         #[arg(short)]
         from_user: bool,
     },
+    /// Get the latest direct messages for admin
+    GetAdminDm {
+        /// Since time of the messages in minutes
+        #[arg(short, long)]
+        #[clap(default_value_t = 30)]
+        since: i64,
+        /// If true, get messages from counterparty, otherwise from Mostro
+        #[arg(short)]
+        from_user: bool,
+    },
     /// Send direct message to a user
     SendDm {
         /// Pubkey of the counterpart
@@ -359,7 +369,10 @@ pub async fn run() -> Result<()> {
                 execute_add_invoice(order_id, invoice, &identity_keys, mostro_key, &client).await?
             }
             Commands::GetDm { since, from_user } => {
-                execute_get_dm(since, trade_index, &client, *from_user).await?
+                execute_get_dm(since, trade_index, &client, *from_user, false).await?
+            }
+            Commands::GetAdminDm { since, from_user } => {
+                execute_get_dm(since, trade_index, &client, *from_user, true).await?
             }
             Commands::FiatSent { order_id }
             | Commands::Release { order_id }

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -80,9 +80,10 @@ pub async fn execute_get_dm(
                         println!();
                     }
                     Payload::Order(new_order) if message.action == Action::NewOrder => {
-                        let db_order =
-                            Order::get_by_id(&pool, &new_order.id.unwrap().to_string()).await;
-                        if db_order.is_err() {
+                        if new_order.id.is_some() {
+                            let db_order =
+                                Order::get_by_id(&pool, &new_order.id.unwrap().to_string()).await;
+                            if db_order.is_err() {
                             let trade_index = message.trade_index.unwrap();
                             let trade_keys = User::get_trade_keys(&pool, trade_index).await?;
                             let _ = Order::new(&pool, new_order.clone(), &trade_keys, None)
@@ -90,6 +91,7 @@ pub async fn execute_get_dm(
                                 .map_err(|e| {
                                     anyhow::anyhow!("Failed to create DB order: {:?}", e)
                                 })?;
+                            }
                         }
                         println!();
                         println!("Order: {:#?}", new_order);

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -84,13 +84,13 @@ pub async fn execute_get_dm(
                             let db_order =
                                 Order::get_by_id(&pool, &new_order.id.unwrap().to_string()).await;
                             if db_order.is_err() {
-                            let trade_index = message.trade_index.unwrap();
-                            let trade_keys = User::get_trade_keys(&pool, trade_index).await?;
-                            let _ = Order::new(&pool, new_order.clone(), &trade_keys, None)
-                                .await
-                                .map_err(|e| {
-                                    anyhow::anyhow!("Failed to create DB order: {:?}", e)
-                                })?;
+                                let trade_index = message.trade_index.unwrap();
+                                let trade_keys = User::get_trade_keys(&pool, trade_index).await?;
+                                let _ = Order::new(&pool, new_order.clone(), &trade_keys, None)
+                                    .await
+                                    .map_err(|e| {
+                                        anyhow::anyhow!("Failed to create DB order: {:?}", e)
+                                    })?;
                             }
                         }
                         println!();

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -13,12 +13,25 @@ pub async fn execute_get_dm(
     trade_index: i64,
     client: &Client,
     from_user: bool,
+    admin: bool,
 ) -> Result<()> {
     let mut dm: Vec<(Message, u64)> = Vec::new();
     let pool = connect().await?;
-    for index in 1..=trade_index {
-        let keys = User::get_trade_keys(&pool, index).await?;
-        let dm_temp = get_direct_messages(client, &keys, *since, from_user).await;
+    if !admin {
+        for index in 1..=trade_index {
+            let keys = User::get_trade_keys(&pool, index).await?;
+            let dm_temp = get_direct_messages(client, &keys, *since, from_user).await;
+            dm.extend(dm_temp);
+        }
+    } else {
+        let id_key = match std::env::var("NSEC_PRIVKEY") {
+            Ok(id_key) => Keys::parse(&id_key)?,
+            Err(e) => {
+                println!("Failed to get mostro admin private key: {}", e);
+                std::process::exit(1);
+            }
+        };
+        let dm_temp = get_direct_messages(client, &id_key, *since, from_user).await;
         dm.extend(dm_temp);
     }
 
@@ -48,6 +61,18 @@ pub async fn execute_get_dm(
                         println!();
                         println!("{text}");
                         println!();
+                    }
+                    Payload::Dispute(id, token, info) => {
+                        println!("Action: {}", message.action);
+                        println!("Dispute id: {}", id);
+                        if token.is_some() {
+                            println!("Dispute token: {}", token.unwrap());
+                        }
+                        if info.is_some() {
+                            println!();
+                            println!("Dispute info: {:#?}", info);
+                            println!();
+                        }
                     }
                     Payload::CantDo(Some(cant_do_reason)) => {
                         println!();

--- a/src/cli/send_dm.rs
+++ b/src/cli/send_dm.rs
@@ -32,7 +32,6 @@ pub async fn execute_send_dm(
         std::process::exit(0)
     };
 
-
     send_message_sync(client, None, &trade_keys, receiver, message, true, true).await?;
 
     Ok(())

--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -1,9 +1,44 @@
 use anyhow::Result;
-use mostro_core::message::{Action, Message};
+use mostro_core::message::{Action, Message, Payload};
 use nostr_sdk::prelude::*;
 use uuid::Uuid;
 
 use crate::util::send_message_sync;
+
+pub async fn execute_admin_add_solver(
+    npubkey: &str,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_key: PublicKey,
+    client: &Client,
+) -> Result<()> {
+    println!(
+        "Request of add solver with pubkey {} from mostro pubId {}",
+        npubkey,
+        mostro_key.clone()
+    );
+    // Create takebuy message
+    let take_dispute_message = Message::new_dispute(
+        Some(Uuid::new_v4()),
+        None,
+        None,
+        Action::AdminAddSolver,
+        Some(Payload::TextMessage(npubkey.to_string())),
+    );
+
+    send_message_sync(
+        client,
+        Some(identity_keys),
+        trade_keys,
+        mostro_key,
+        take_dispute_message,
+        true,
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
 
 pub async fn execute_admin_cancel_dispute(
     dispute_id: &Uuid,

--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -5,6 +5,70 @@ use uuid::Uuid;
 
 use crate::util::send_message_sync;
 
+pub async fn execute_admin_cancel_dispute(
+    dispute_id: &Uuid,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_key: PublicKey,
+    client: &Client,
+) -> Result<()> {
+    println!(
+        "Request of cancel dispute {} from mostro pubId {}",
+        dispute_id,
+        mostro_key.clone()
+    );
+    // Create takebuy message
+    let take_dispute_message =
+        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminCancel, None);
+
+    println!("identity_keys: {:?}", identity_keys.public_key.to_string());
+
+    send_message_sync(
+        client,
+        Some(identity_keys),
+        trade_keys,
+        mostro_key,
+        take_dispute_message,
+        true,
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+pub async fn execute_admin_settle_dispute(
+    dispute_id: &Uuid,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_key: PublicKey,
+    client: &Client,
+) -> Result<()> {
+    println!(
+        "Request of take dispute {} from mostro pubId {}",
+        dispute_id,
+        mostro_key.clone()
+    );
+    // Create takebuy message
+    let take_dispute_message =
+        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminSettle, None);
+
+    println!("identity_keys: {:?}", identity_keys.public_key.to_string());
+
+    send_message_sync(
+        client,
+        Some(identity_keys),
+        trade_keys,
+        mostro_key,
+        take_dispute_message,
+        true,
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
 pub async fn execute_take_dispute(
     dispute_id: &Uuid,
     identity_keys: &Keys,
@@ -25,6 +89,8 @@ pub async fn execute_take_dispute(
         Action::AdminTakeDispute,
         None,
     );
+
+    println!("identity_keys: {:?}", identity_keys.public_key.to_string());
 
     send_message_sync(
         client,

--- a/src/cli/take_sell.rs
+++ b/src/cli/take_sell.rs
@@ -29,9 +29,9 @@ pub async fn execute_take_sell(
 
     let payload = match invoice {
         Some(inv) => {
-            let initial_payload = match LightningAddress::from_str(&inv) {
+            let initial_payload = match LightningAddress::from_str(inv) {
                 Ok(_) => Payload::PaymentRequest(None, inv.to_string(), None),
-                Err(_) => match is_valid_invoice(&inv) {
+                Err(_) => match is_valid_invoice(inv) {
                     Ok(i) => Payload::PaymentRequest(None, i.to_string(), None),
                     Err(e) => {
                         println!("{}", e);

--- a/src/util.rs
+++ b/src/util.rs
@@ -200,8 +200,8 @@ pub async fn get_direct_messages(
                     let unencrypted_content = decrypt_to_bytes(&ck, &b64decoded_content)
                         .expect("Failed to decrypt message");
 
-                    let message = String::from_utf8(unencrypted_content)
-                        .expect("Found invalid UTF-8");
+                    let message =
+                        String::from_utf8(unencrypted_content).expect("Found invalid UTF-8");
                     let message = Message::from_json(&message).expect("Failed on deserializing");
 
                     (dm.created_at, message)


### PR DESCRIPTION
@grunch ,

this is the pr with my addiction for:
- getting dm as mostro admin 
- Settling and canceling disputes as admin

To get info message use new getadmindm command which will use private key in your .env file to request mostro admin messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced administrative commands for accessing direct messages and managing disputes, enabling actions such as retrieving specialized messages and canceling or settling disputes.
	- Extended the messaging functionality to support an administrative perspective with additional parameters.
- **Bug Fixes**
	- Standardized error handling for accessing sensitive operations, ensuring proper notifications on failures.
- **Style**
	- Applied minor formatting improvements to increase overall readability.
- **Chores**
	- Updated the version of the `mostro-core` dependency to enhance library functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->