### PR TITLE
change payment_method type to string array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.6.40"
+version = "0.6.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4f00613761cd385d337943da90de5ac5dd4a58ecb7cb2385710edc4347fde5"
+checksum = "1b07af3adb16a2c6e28837896ce93ad5bf19a9c91aefc0bcdde32462011b9adf"
 dependencies = [
  "argon2",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ uuid = { version = "1.3.0", features = [
 dotenvy = "0.15.6"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
 reqwest = { version = "0.12.4", features = ["json"] }
-mostro-core = "0.6.40"  
+mostro-core = "0.6.41"  
 lnurl-rs = "0.9.0"
 pretty_env_logger = "0.5.0"
 openssl = { version = "0.10.68", features = ["vendored"] }

--- a/src/cli/new_order.rs
+++ b/src/cli/new_order.rs
@@ -19,7 +19,7 @@ pub async fn execute_new_order(
     fiat_code: &str,
     fiat_amount: &(i64, Option<i64>),
     amount: &i64,
-    payment_method: &String,
+    payment_method: &str,
     premium: &i64,
     invoice: &Option<String>,
     identity_keys: &Keys,
@@ -57,6 +57,10 @@ pub async fn execute_new_order(
             Some(expires_at.timestamp())
         }
     };
+    let payment_method = payment_method
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect::<Vec<String>>();
 
     // Get the type of neworder
     // if both tuple field are valid than it's a range order

--- a/src/db.rs
+++ b/src/db.rs
@@ -233,6 +233,8 @@ impl Order {
             Some(id) => id.to_string(),
             None => uuid::Uuid::new_v4().to_string(),
         };
+        let payment_method =
+            serde_json::to_string(order.payment_method.as_ref() as &[String]).unwrap_or_default();
         let order = Order {
             id: Some(id),
             kind: order.kind.as_ref().map(|k| k.to_string()),
@@ -242,7 +244,7 @@ impl Order {
             min_amount: order.min_amount,
             max_amount: order.max_amount,
             fiat_amount: order.fiat_amount,
-            payment_method: order.payment_method,
+            payment_method,
             premium: order.premium,
             trade_keys: Some(trade_keys_hex),
             counterparty_pubkey: None,

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,4 +1,5 @@
 use anyhow::{Ok, Result};
+use mostro_core::order::Kind;
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use std::str::FromStr;
@@ -6,48 +7,50 @@ use uuid::Uuid;
 
 pub fn order_from_tags(tags: Tags) -> Result<SmallOrder> {
     let mut order = SmallOrder::default();
+
     for tag in tags {
-        let t = tag.to_vec();
-        let v = t.get(1).unwrap().as_str();
-        match t.first().unwrap().as_str() {
+        let t = tag.to_vec(); // Vec<String>
+        if t.is_empty() {
+            continue;
+        }
+
+        let key = t[0].as_str();
+        let values = &t[1..];
+
+        let v = values.get(0).map(|s| s.as_str()).unwrap_or_default();
+
+        match key {
             "d" => {
-                let id = v.parse::<Uuid>();
-                let id = match id {
-                    core::result::Result::Ok(id) => Some(id),
-                    Err(_) => None,
-                };
-                order.id = id;
+                order.id = Uuid::parse_str(v).ok();
             }
             "k" => {
-                order.kind = Some(mostro_core::order::Kind::from_str(v).unwrap());
+                order.kind = Kind::from_str(v).ok();
             }
             "f" => {
                 order.fiat_code = v.to_string();
             }
             "s" => {
-                order.status = Some(Status::from_str(v).unwrap_or(Status::Dispute));
+                order.status = Status::from_str(v).ok().or(Some(Status::Dispute));
             }
             "amt" => {
-                order.amount = v.parse::<i64>().unwrap();
+                order.amount = v.parse::<i64>().unwrap_or(0);
             }
             "fa" => {
                 if v.contains('.') {
                     continue;
                 }
-                let max = t.get(2);
-                if max.is_some() {
+                if let Some(max_str) = values.get(1) {
                     order.min_amount = v.parse::<i64>().ok();
-                    order.max_amount = max.unwrap().parse::<i64>().ok();
+                    order.max_amount = max_str.parse::<i64>().ok();
                 } else {
-                    let fa = v.parse::<i64>();
-                    order.fiat_amount = fa.unwrap_or(0);
+                    order.fiat_amount = v.parse::<i64>().unwrap_or(0);
                 }
             }
             "pm" => {
-                order.payment_method = v.to_string();
+                order.payment_method = values.iter().map(|s| s.to_string()).collect();
             }
             "premium" => {
-                order.premium = v.parse::<i64>().unwrap();
+                order.premium = v.parse::<i64>().unwrap_or(0);
             }
             _ => {}
         }

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -17,7 +17,7 @@ pub fn order_from_tags(tags: Tags) -> Result<SmallOrder> {
         let key = t[0].as_str();
         let values = &t[1..];
 
-        let v = values.get(0).map(|s| s.as_str()).unwrap_or_default();
+        let v = values.first().map(|s| s.as_str()).unwrap_or_default();
 
         match key {
             "d" => {
@@ -30,7 +30,7 @@ pub fn order_from_tags(tags: Tags) -> Result<SmallOrder> {
                 order.fiat_code = v.to_string();
             }
             "s" => {
-                order.status = Status::from_str(v).ok().or(Some(Status::Dispute));
+                order.status = Status::from_str(v).ok().or(Some(Status::Pending));
             }
             "amt" => {
                 order.amount = v.parse::<i64>().unwrap_or(0);

--- a/src/pretty_table.rs
+++ b/src/pretty_table.rs
@@ -4,7 +4,6 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::*;
 use mostro_core::prelude::*;
 
-
 pub fn print_order_preview(ord: Payload) -> Result<String, String> {
     let single_order = match ord {
         Payload::Order(o) => o,
@@ -69,7 +68,7 @@ pub fn print_order_preview(ord: Payload) -> Result<String, String> {
             );
             Cell::new(range_str).set_alignment(CellAlignment::Center)
         },
-        Cell::new(single_order.payment_method.to_string()).set_alignment(CellAlignment::Center),
+        Cell::new(single_order.payment_method.join(", ")).set_alignment(CellAlignment::Center),
         Cell::new(single_order.premium.to_string()).set_alignment(CellAlignment::Center),
     ]);
 
@@ -174,7 +173,7 @@ pub fn print_orders_table(orders_table: Vec<SmallOrder>) -> Result<String> {
                     );
                     Cell::new(range_str).set_alignment(CellAlignment::Center)
                 },
-                Cell::new(single_order.payment_method.to_string())
+                Cell::new(single_order.payment_method.join(", "))
                     .set_alignment(CellAlignment::Center),
                 Cell::new(date.unwrap()),
             ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved robustness and error handling when parsing order tags, reducing the risk of application crashes due to malformed input.
- **Refactor**
	- Updated how payment methods are handled and displayed: now supports multiple payment methods, shown as a comma-separated list in order tables and previews.
- **Chores**
	- Updated a dependency to the latest version for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->