### PR TITLE
feat: add admin-to-user and user-to-user communication via gift wraps

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -433,8 +433,7 @@ pub async fn run() -> Result<()> {
                 let id_key = match std::env::var("NSEC_PRIVKEY") {
                     Ok(id_key) => Keys::parse(&id_key)?,
                     Err(e) => {
-                        println!("Failed to get mostro admin private key: {}", e);
-                        std::process::exit(1);
+                        anyhow::bail!("NSEC_PRIVKEY not set: {e}");
                     }
                 };
                 execute_admin_add_solver(npubkey, &id_key, &trade_keys, mostro_key, &client).await?
@@ -476,8 +475,7 @@ pub async fn run() -> Result<()> {
                 let id_key = match std::env::var("NSEC_PRIVKEY") {
                     Ok(id_key) => Keys::parse(&id_key)?,
                     Err(e) => {
-                        println!("Failed to get mostro admin private key: {}", e);
-                        std::process::exit(1);
+                        anyhow::bail!("NSEC_PRIVKEY not set: {e}");
                     }
                 };
                 execute_admin_settle_dispute(order_id, &id_key, &trade_keys, mostro_key, &client)
@@ -487,8 +485,7 @@ pub async fn run() -> Result<()> {
                 let id_key = match std::env::var("NSEC_PRIVKEY") {
                     Ok(id_key) => Keys::parse(&id_key)?,
                     Err(e) => {
-                        println!("Failed to get mostro admin private key: {}", e);
-                        std::process::exit(1);
+                        anyhow::bail!("NSEC_PRIVKEY not set: {e}");
                     }
                 };
                 execute_admin_cancel_dispute(order_id, &id_key, &trade_keys, mostro_key, &client)
@@ -498,8 +495,7 @@ pub async fn run() -> Result<()> {
                 let id_key = match std::env::var("NSEC_PRIVKEY") {
                     Ok(id_key) => Keys::parse(&id_key)?,
                     Err(e) => {
-                        println!("Failed to get mostro admin private key: {}", e);
-                        std::process::exit(1);
+                        anyhow::bail!("NSEC_PRIVKEY not set: {e}");
                     }
                 };
 

--- a/src/cli/adm_send_dm.rs
+++ b/src/cli/adm_send_dm.rs
@@ -1,0 +1,26 @@
+use crate::util::send_admin_gift_wrap_dm;
+use anyhow::Result;
+use nostr_sdk::prelude::*;
+
+pub async fn execute_adm_send_dm(
+    receiver: PublicKey,
+    client: &Client,
+    message: &str,
+) -> Result<()> {
+    let admin_keys = match std::env::var("NSEC_PRIVKEY") {
+        Ok(key) => Keys::parse(&key)?,
+        Err(e) => {
+            println!("Failed to get admin private key: {}", e);
+            println!("Make sure NSEC_PRIVKEY environment variable is set");
+            std::process::exit(1);
+        }
+    };
+
+    println!("SENDING DM with admin keys: {}", admin_keys.public_key().to_hex());
+
+    send_admin_gift_wrap_dm(client, &admin_keys, &receiver, message).await?;
+
+    println!("Admin gift wrap message sent to {}", receiver);
+
+    Ok(())
+}

--- a/src/cli/adm_send_dm.rs
+++ b/src/cli/adm_send_dm.rs
@@ -10,9 +10,7 @@ pub async fn execute_adm_send_dm(
     let admin_keys = match std::env::var("NSEC_PRIVKEY") {
         Ok(key) => Keys::parse(&key)?,
         Err(e) => {
-            println!("Failed to get admin private key: {}", e);
-            println!("Make sure NSEC_PRIVKEY environment variable is set");
-            std::process::exit(1);
+            anyhow::bail!("NSEC_PRIVKEY not set: {e}");
         }
     };
 

--- a/src/cli/dm_to_user.rs
+++ b/src/cli/dm_to_user.rs
@@ -1,0 +1,31 @@
+use crate::{db::Order, util::send_gift_wrap_dm};
+use anyhow::Result;
+use nostr_sdk::prelude::*;
+use uuid::Uuid;
+
+pub async fn execute_dm_to_user(
+    receiver: PublicKey,
+    client: &Client,
+    order_id: &Uuid,
+    message: &str,
+) -> Result<()> {
+    let pool = crate::db::connect().await?;
+
+    let trade_keys = if let Ok(order) = Order::get_by_id(&pool, &order_id.to_string()).await {
+        match order.trade_keys.as_ref() {
+            Some(trade_keys) => Keys::parse(trade_keys)?,
+            None => {
+                anyhow::bail!("No trade_keys found for this order");
+            }
+        }
+    } else {
+        println!("order {} not found", order_id);
+        std::process::exit(0)
+    };
+
+    println!("SENDING DM with trade keys: {}", trade_keys.public_key().to_hex());
+
+    send_gift_wrap_dm(client, &trade_keys, &receiver, message).await?;
+
+    Ok(())
+}

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -21,7 +21,7 @@ pub async fn execute_get_dm(
     if !admin {
         for index in 1..=trade_index {
             let keys = User::get_trade_keys(&pool, index).await?;
-            let dm_temp = get_direct_messages(client, &keys, *since, from_user, Some(&mostro_pubkey)).await;
+            let dm_temp = get_direct_messages(client, &keys, *since, from_user, Some(mostro_pubkey)).await;
             dm.extend(dm_temp);
         }
     } else {

--- a/src/cli/get_dm.rs
+++ b/src/cli/get_dm.rs
@@ -14,13 +14,14 @@ pub async fn execute_get_dm(
     client: &Client,
     from_user: bool,
     admin: bool,
+    mostro_pubkey: &PublicKey,
 ) -> Result<()> {
     let mut dm: Vec<(Message, u64)> = Vec::new();
     let pool = connect().await?;
     if !admin {
         for index in 1..=trade_index {
             let keys = User::get_trade_keys(&pool, index).await?;
-            let dm_temp = get_direct_messages(client, &keys, *since, from_user).await;
+            let dm_temp = get_direct_messages(client, &keys, *since, from_user, Some(&mostro_pubkey)).await;
             dm.extend(dm_temp);
         }
     } else {
@@ -31,7 +32,7 @@ pub async fn execute_get_dm(
                 std::process::exit(1);
             }
         };
-        let dm_temp = get_direct_messages(client, &id_key, *since, from_user).await;
+        let dm_temp = get_direct_messages(client, &id_key, *since, from_user, Some(mostro_pubkey)).await;
         dm.extend(dm_temp);
     }
 

--- a/src/cli/get_dm_user.rs
+++ b/src/cli/get_dm_user.rs
@@ -1,0 +1,62 @@
+use crate::{db::Order, util::get_direct_messages_from_trade_keys};
+use anyhow::Result;
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::presets::UTF8_FULL;
+use comfy_table::Table;
+use mostro_core::prelude::*;
+use nostr_sdk::prelude::*;
+
+pub async fn execute_get_dm_user(since: &i64, client: &Client, mostro_pubkey: &PublicKey) -> Result<()> {
+    let pool = crate::db::connect().await?;
+    
+    // Get all trade keys from orders
+    let mut trade_keys_hex = Order::get_all_trade_keys(&pool).await?;
+    
+    // Add admin private key to search for messages sent TO admin
+    if let Ok(admin_privkey_hex) = std::env::var("NSEC_PRIVKEY") {
+        trade_keys_hex.push(admin_privkey_hex);
+    }
+    
+    if trade_keys_hex.is_empty() {
+        println!("No trade keys found in orders and NSEC_PRIVKEY not set");
+        return Ok(());
+    }
+    
+    println!("Searching for DMs in {} trade keys...", trade_keys_hex.len());
+    
+    let direct_messages = get_direct_messages_from_trade_keys(client, trade_keys_hex, *since, mostro_pubkey).await;
+
+    if direct_messages.is_empty() {
+        println!("You don't have any direct messages in your trade keys");
+        return Ok(());
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(comfy_table::ContentArrangement::Dynamic)
+        .set_header(vec!["Time", "From", "Message"]);
+
+    for (message, created_at, sender_pubkey) in direct_messages.iter() {
+        let datetime = chrono::DateTime::from_timestamp(*created_at as i64, 0);
+        let formatted_date = match datetime {
+            Some(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            None => "Invalid timestamp".to_string(),
+        };
+
+        let inner = message.get_inner_message_kind();
+        let message_str = match &inner.payload {
+            Some(Payload::TextMessage(text)) => text.clone(),
+            _ => format!("{:?}", message),
+        };
+
+        let sender_hex = sender_pubkey.to_hex();
+
+        table.add_row(vec![&formatted_date, &sender_hex, &message_str]);
+    }
+
+    println!("{table}");
+    println!();
+    Ok(())
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -439,6 +439,26 @@ impl Order {
         Ok(orders)
     }
 
+    pub async fn get_all_trade_keys(pool: &SqlitePool) -> Result<Vec<String>> {
+        #[derive(sqlx::FromRow)]
+        struct TradeKeyRow {
+            trade_keys: Option<String>,
+        }
+
+        let rows = sqlx::query_as::<_, TradeKeyRow>(
+            "SELECT DISTINCT trade_keys FROM orders WHERE trade_keys IS NOT NULL"
+        )
+        .fetch_all(pool)
+        .await?;
+        
+        let trade_keys: Vec<String> = rows
+            .into_iter()
+            .filter_map(|row| row.trade_keys)
+            .collect();
+        
+        Ok(trade_keys)
+    }
+
     pub async fn delete_by_id(pool: &SqlitePool, id: &str) -> Result<bool> {
         let rows_affected = sqlx::query(
             r#"

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,6 +12,72 @@ use std::thread::sleep;
 use std::time::Duration;
 use std::{fs, path::Path};
 
+pub async fn send_admin_gift_wrap_dm(
+    client: &Client,
+    admin_keys: &Keys,
+    receiver_pubkey: &PublicKey,
+    message: &str,
+) -> Result<()> {
+    let pow: u8 = var("POW").unwrap_or('0'.to_string()).parse().unwrap();
+    
+    // Create Message struct for consistency with Mostro protocol
+    let dm_message = Message::new_dm(
+        None,
+        None,
+        Action::SendDm,
+        Some(Payload::TextMessage(message.to_string())),
+    );
+    
+    // Serialize as JSON with the expected format (Message, Option<Signature>)
+    let content = serde_json::to_string(&(dm_message, None::<String>))?;
+    
+    // Create the rumor with JSON content
+    let rumor = EventBuilder::text_note(content)
+        .pow(pow)
+        .build(admin_keys.public_key());
+    
+    // Create gift wrap using admin_keys as the signing key
+    let event = EventBuilder::gift_wrap(admin_keys, receiver_pubkey, rumor, Tags::new()).await?;
+    
+    info!("Sending admin gift wrap event: {event:#?}");
+    client.send_event(&event).await?;
+    
+    Ok(())
+}
+
+pub async fn send_gift_wrap_dm(
+    client: &Client,
+    trade_keys: &Keys,
+    receiver_pubkey: &PublicKey,
+    message: &str,
+) -> Result<()> {
+    let pow: u8 = var("POW").unwrap_or('0'.to_string()).parse().unwrap();
+    
+    // Create Message struct for consistency with Mostro protocol
+    let dm_message = Message::new_dm(
+        None,
+        None,
+        Action::SendDm,
+        Some(Payload::TextMessage(message.to_string())),
+    );
+    
+    // Serialize as JSON with the expected format (Message, Option<Signature>)
+    let content = serde_json::to_string(&(dm_message, None::<String>))?;
+    
+    // Create the rumor with JSON content
+    let rumor = EventBuilder::text_note(content)
+        .pow(pow)
+        .build(trade_keys.public_key());
+    
+    // Create gift wrap using trade_keys as ephemeral key
+    let event = EventBuilder::gift_wrap(trade_keys, receiver_pubkey, rumor, Tags::new()).await?;
+    
+    info!("Sending gift wrap event: {event:#?}");
+    client.send_event(&event).await?;
+    
+    Ok(())
+}
+
 pub async fn send_dm(
     client: &Client,
     identity_keys: Option<&Keys>,
@@ -131,7 +197,7 @@ pub async fn send_message_sync(
     sleep(Duration::from_secs(2));
 
     let dm: Vec<(Message, u64)> = if wait_for_dm {
-        get_direct_messages(client, trade_keys, 15, to_user).await
+        get_direct_messages(client, trade_keys, 15, to_user, None).await
     } else {
         Vec::new()
     };
@@ -139,11 +205,89 @@ pub async fn send_message_sync(
     Ok(dm)
 }
 
+pub async fn get_direct_messages_from_trade_keys(
+    client: &Client,
+    trade_keys_hex: Vec<String>,
+    since: i64,
+    mostro_pubkey: &PublicKey,
+) -> Vec<(Message, u64, PublicKey)> {
+    let fake_since = 2880;
+    let fake_since_time = chrono::Utc::now()
+        .checked_sub_signed(chrono::Duration::minutes(fake_since))
+        .unwrap()
+        .timestamp() as u64;
+    let fake_timestamp = Timestamp::from(fake_since_time);
+
+    let mut all_direct_messages: Vec<(Message, u64, PublicKey)> = Vec::new();
+    let mut id_list = Vec::<EventId>::new();
+
+    for trade_key_hex in trade_keys_hex {
+        if let Ok(trade_keys) = Keys::parse(&trade_key_hex) {
+            let filters = Filter::new()
+                .kind(nostr_sdk::Kind::GiftWrap)
+                .pubkey(trade_keys.public_key())
+                .since(fake_timestamp);
+
+            info!("Request events with event kind : {:?} for trade key: {}", 
+                  filters.kinds, trade_keys.public_key());
+
+            if let Ok(events) = client.fetch_events(filters, Duration::from_secs(15)).await {
+                for dm in events.iter() {
+                    if !id_list.contains(&dm.id) {
+                        id_list.push(dm.id);
+                        
+                        let unwrapped_gift = match nip59::extract_rumor(&trade_keys, dm).await {
+                            Ok(u) => u,
+                            Err(_) => {
+                                println!("Error unwrapping gift for trade key: {}", trade_keys.public_key());
+                                continue;
+                            }
+                        };
+                        
+                        // Filter: only process messages NOT from Mostro (user-to-user messages)
+                        if unwrapped_gift.rumor.pubkey == *mostro_pubkey {
+                            continue; // Skip Mostro messages
+                        }
+                        
+                        let since_time = chrono::Utc::now()
+                            .checked_sub_signed(chrono::Duration::minutes(since))
+                            .unwrap()
+                            .timestamp() as u64;
+
+                        if unwrapped_gift.rumor.created_at.as_u64() < since_time {
+                            continue;
+                        }
+
+                        // Parse JSON content (all messages should be JSON now)
+                        let (message, _): (Message, Option<String>) = match serde_json::from_str(&unwrapped_gift.rumor.content) {
+                            Ok(parsed) => parsed,
+                            Err(_) => {
+                                println!("Error parsing JSON content from: {}", unwrapped_gift.rumor.pubkey);
+                                continue;
+                            }
+                        };
+                        
+                        all_direct_messages.push((
+                            message, 
+                            unwrapped_gift.rumor.created_at.as_u64(),
+                            unwrapped_gift.rumor.pubkey
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    all_direct_messages.sort_by(|a, b| a.1.cmp(&b.1));
+    all_direct_messages
+}
+
 pub async fn get_direct_messages(
     client: &Client,
     my_key: &Keys,
     since: i64,
     from_user: bool,
+    mostro_pubkey: Option<&PublicKey>,
 ) -> Vec<(Message, u64)> {
     // We use a fake timestamp to thwart time-analysis attacks
     let fake_since = 2880;
@@ -213,6 +357,14 @@ pub async fn get_direct_messages(
                             continue;
                         }
                     };
+                    
+                    // Filter: only process messages from Mostro
+                    if let Some(mostro_pk) = mostro_pubkey {
+                        if unwrapped_gift.rumor.pubkey != *mostro_pk {
+                            continue; // Skip non-Mostro messages
+                        }
+                    }
+                    
                     let (message, _): (Message, Option<String>) =
                         serde_json::from_str(&unwrapped_gift.rumor.content).unwrap();
 


### PR DESCRIPTION
  - Add dmtouser command: send gift wrapped messages between users using trade keys from order IDs
  - Add admsenddm command: admin can send gift wrapped messages to users
  - Add getdmuser command: view gift wrapped messages received on trade keys 
  - Filter messages by sender: getdm shows only Mostro messages (admin sends messages with mostro key), getdmuser shows only user messages

  New commands:
  - mostro-cli dmtouser -p <pubkey> -o <order_id> -m <message>
  - mostro-cli admsenddm -p <pubkey> -m <message>
  - mostro-cli getdmuser -s <minutes>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New CLI commands to send user-linked DMs, send admin DMs, and retrieve user DMs since a given time.
  - Added gift-wrapped DM sending and multi-key DM retrieval.
  - Retrieved DMs are shown in a readable table (time, sender, message).

- Improvements
  - Mostro-aware filtering threaded through DM retrieval for more accurate results and clearer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->