### PR TITLE
Fixed wrong key in execute_admin_add_solver function

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -28,6 +28,10 @@ That will verify the signature of the manifest file, which ensures integrity and
 ## What's Changed
 
 {%- if version %} in {{ version }}{%- endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+{% if group != "" %}
+### {{ group }}
+{% endif %}
 {% for commit in commits %}
   {% if commit.remote.pr_title -%}
     {%- set commit_message = commit.remote.pr_title -%}
@@ -39,6 +43,7 @@ That will verify the signature of the manifest file, which ensures integrity and
     {% if commit.remote.pr_number %} in \
       [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}) \
     {%- endif %}
+{%- endfor %}
 {%- endfor -%}
 
 {%- if github -%}
@@ -75,25 +80,26 @@ footer = """
 """
 # An array of regex based postprocessors to modify the changelog.
 # Replace the placeholder `<REPO>` with a URL.
-postprocessors = []
-
+postprocessors = [{ pattern = "<!-- \\d+ -->", replace = "" }]
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "^feat", group = "<!-- 0 -->🚀 Features" },
-  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
-  { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
-  { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
-  { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
-  { message = "^style", group = "<!-- 5 -->🎨 Styling" },
-  { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+  { message = "^feat(\\(.+\\))?!?:", group = "🚀 Features" },
+  { message = "^fix(\\(.+\\))?!?:", group = "🐛 Bug Fixes" },
+  { message = "^docs(\\(.+\\))?!?:", group = "📚 Documentation" },
+  { message = "^perf(\\(.+\\))?!?:", group = "⚡ Performance" },
+  { message = "^refactor(\\(.+\\))?!?:", group = "🚜 Refactor" },
+  { message = "^style(\\(.+\\))?!?:", group = "🎨 Styling" },
+  { message = "^test(\\(.+\\))?!?:", group = "🧪 Testing" },
+  { message = "^ci(\\(.+\\))?!?:", group = "⚙️ CI/CD" },
+  { message = "^build(\\(.+\\))?!?:", group = "🔨 Build" },
   { message = "^chore\\(release\\): prepare for", skip = true },
   { message = "^chore\\(deps.*\\)", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },
-  { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
-  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
-  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
-  { message = ".*", group = "<!-- 10 -->💼 Other" },
+  { message = "^chore(\\(.+\\))?!?:", group = "⚙️ Miscellaneous Tasks" },
+  { body = "(?i)security", group = "🛡️ Security" },
+  { message = "^revert", group = "◀️ Revert" },
+  { message = ".*", group = "💼 Other" },
 ]
 
 [git]

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,7 +4,6 @@
 [remote.github]
 owner = "MostroP2P"
 repo = "mostro-cli"
-token = "${GITHUB_TOKEN}"
 
 [changelog]
 # A Tera template to be rendered for each release in the changelog.
@@ -43,12 +42,12 @@ That will verify the signature of the manifest file, which ensures integrity and
 {%- endfor -%}
 
 {%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+{% if github.contributors | length != 0 %}
   {% raw %}\n{% endraw -%}
-  ## New Contributors
+  ## Contributors
 {%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * @{{ contributor.username }} made their first contribution
+{% for contributor in github.contributors %}
+  * @{{ contributor.username }} made their contribution
     {%- if contributor.pr_number %} in \
       [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
     {%- endif %}
@@ -77,6 +76,25 @@ footer = """
 # An array of regex based postprocessors to modify the changelog.
 # Replace the placeholder `<REPO>` with a URL.
 postprocessors = []
+
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+  { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+  { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+  { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+  { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "^chore\\(deps.*\\)", skip = true },
+  { message = "^chore\\(pr\\)", skip = true },
+  { message = "^chore\\(pull\\)", skip = true },
+  { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+  { message = ".*", group = "<!-- 10 -->💼 Other" },
+]
 
 [git]
 # Parse commits according to the conventional commits specification.

--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use mostro_core::prelude::*;
 use uuid::Uuid;
 
-use crate::{cli::Context, util::send_dm};
+use crate::{cli::Context, util::admin_send_dm};
 
 pub async fn execute_admin_add_solver(npubkey: &str, ctx: &Context) -> Result<()> {
     println!(
@@ -20,16 +20,7 @@ pub async fn execute_admin_add_solver(npubkey: &str, ctx: &Context) -> Result<()
     .as_json()
     .map_err(|_| anyhow::anyhow!("Failed to serialize message"))?;
 
-    send_dm(
-        &ctx.client,
-        Some(&ctx.context_keys),
-        &ctx.trade_keys,
-        &ctx.mostro_pubkey,
-        take_dispute_message,
-        None,
-        false,
-    )
-    .await?;
+    admin_send_dm(ctx, take_dispute_message).await?;
 
     Ok(())
 }
@@ -48,16 +39,7 @@ pub async fn execute_admin_cancel_dispute(dispute_id: &Uuid, ctx: &Context) -> R
 
     println!("Admin keys: {:?}", ctx.context_keys.public_key.to_string());
 
-    send_dm(
-        &ctx.client,
-        Some(&ctx.context_keys),
-        &ctx.trade_keys,
-        &ctx.mostro_pubkey,
-        take_dispute_message,
-        None,
-        false,
-    )
-    .await?;
+    admin_send_dm(ctx, take_dispute_message).await?;
 
     Ok(())
 }
@@ -75,18 +57,7 @@ pub async fn execute_admin_settle_dispute(dispute_id: &Uuid, ctx: &Context) -> R
             .map_err(|_| anyhow::anyhow!("Failed to serialize message"))?;
 
     println!("Admin keys: {:?}", ctx.context_keys.public_key.to_string());
-
-    send_dm(
-        &ctx.client,
-        Some(&ctx.context_keys),
-        &ctx.trade_keys,
-        &ctx.mostro_pubkey,
-        take_dispute_message,
-        None,
-        false,
-    )
-    .await?;
-
+    admin_send_dm(ctx, take_dispute_message).await?;
     Ok(())
 }
 
@@ -109,16 +80,6 @@ pub async fn execute_take_dispute(dispute_id: &Uuid, ctx: &Context) -> Result<()
 
     println!("Admin keys: {:?}", ctx.context_keys.public_key.to_string());
 
-    send_dm(
-        &ctx.client,
-        Some(&ctx.context_keys),
-        &ctx.trade_keys,
-        &ctx.mostro_pubkey,
-        take_dispute_message,
-        None,
-        false,
-    )
-    .await?;
-
+    admin_send_dm(ctx, take_dispute_message).await?;
     Ok(())
 }

--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -22,7 +22,7 @@ pub async fn execute_admin_add_solver(npubkey: &str, ctx: &Context) -> Result<()
 
     send_dm(
         &ctx.client,
-        Some(&ctx.identity_keys),
+        Some(&ctx.context_keys),
         &ctx.trade_keys,
         &ctx.mostro_pubkey,
         take_dispute_message,

--- a/src/util.rs
+++ b/src/util.rs
@@ -662,5 +662,20 @@ pub async fn run_simple_order_msg(command: Commands, order_id: &Uuid, ctx: &Cont
     execute_send_msg(command, Some(*order_id), ctx, None).await
 }
 
+// helper (place near other CLI utils)
+pub async fn admin_send_dm(ctx: &Context, msg: String) -> anyhow::Result<()> {
+    send_dm(
+        &ctx.client,
+        Some(&ctx.context_keys),
+        &ctx.trade_keys,
+        &ctx.mostro_pubkey,
+        msg,
+        None,
+        false,
+    )
+    .await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {}


### PR DESCRIPTION
@grunch ,

- fixed wrong key sended in admin add solver command
- removed first committer part from `cliff.toml` and added the emoticons for different parts as in mostro and mostro-core

Now commit with changelog is created by github actions and then committed remotely, so in the end there is one more automatic commit, but we removed git cliff boilerplate from `cargo.toml`. Let me know if you like this or we can use the same trick everywhere and let the commit be made locally without the automatic one.

This new way has pros:
- no more problems with gh api rate limit
- no more boilerplate code in cargo.toml to preprocess and commit changelog

cons:
- one commit more is generated for changelog

in both cases then we can have releases autobuild with nice changelog!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Revamped changelog formatting with clearer commit groupings, emoji-labeled categories, skip/fallback rules, and a fallback category.
  - Updated contributor section to list all contributors under “Contributors,” with improved PR link handling.
  - Changelog now respects conventional-style commits and shows newest commits first.

- Chores
  - Removed GitHub token reference from remote configuration.
  - Added comprehensive commit parsing, grouping, and preprocessing rules for consistent changelog entries.

- Refactor
  - Simplified admin direct-message handling in dispute tooling to use a centralized messaging helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->