### PR TITLE
Fix timeout error when initiating disputes

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -263,6 +263,16 @@ pub async fn wait_for_dm(
                                 }
                             }
                         }
+                        // this is the case where the user initiates a dispute
+                        Action::DisputeInitiatedByYou => {
+                            if let Some(Payload::Dispute(dispute_id, _)) = &message.payload {
+                                println!("Dispute initiated successfully with ID: {}", dispute_id);
+                                return Ok(());
+                            } else {
+                                println!("Dispute initiated successfully");
+                                return Ok(());
+                            }
+                        }
                         _ => {}
                     }
                     }


### PR DESCRIPTION
Fixes timeout issue when running `dispute` command. The CLI was missing a handler for the `DisputeInitiatedByYou` action in [wait_for_dm()](cci:1://file:///home/andrea/Documents/oss/mostrop2p/forks/mostro-cli/src/util.rs:131:0-290:1), causing it to wait until timeout instead of processing the daemon's confirmation message.

Added handler to properly acknowledge dispute initiation and display success message.