### PR TITLE
fix: improve error messages in getadmindm gift wrap decryption

### DIFF
--- a/src/parser/dms.rs
+++ b/src/parser/dms.rs
@@ -25,16 +25,16 @@ pub async fn parse_dm_events(events: Events, pubkey: &Keys) -> Vec<(Message, u64
             nostr_sdk::Kind::GiftWrap => {
                 let unwrapped_gift = match nip59::extract_rumor(pubkey, dm).await {
                     Ok(u) => u,
-                    Err(_) => {
-                        println!("Error unwrapping gift");
+                    Err(e) => {
+                        eprintln!("Warning: Could not decrypt gift wrap (event {}): {}", dm.id, e);
                         continue;
                     }
                 };
                 let (message, _): (Message, Option<String>) =
                     match serde_json::from_str(&unwrapped_gift.rumor.content) {
                         Ok(msg) => msg,
-                        Err(_) => {
-                            println!("Error parsing gift wrap content");
+                        Err(e) => {
+                            eprintln!("Warning: Could not parse message content (event {}): {}", dm.id, e);
                             continue;
                         }
                     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -567,7 +567,8 @@ pub async fn fetch_events_list(
             Ok(orders.into_iter().map(Event::SmallOrder).collect())
         }
         ListKind::DirectMessagesAdmin => {
-            let filters = create_filter(list_kind, ctx.mostro_pubkey, None)?;
+            // Fetch gift wraps sent TO the admin's public key (not Mostro's)
+            let filters = create_filter(list_kind, ctx.context_keys.public_key(), None)?;
             let fetched_events = ctx
                 .client
                 .fetch_events(filters, FETCH_EVENTS_TIMEOUT)


### PR DESCRIPTION
Improved error handling in `getadmindm` by replacing generic "Error unwrapping gift" messages with detailed warnings that include event IDs and specific error reasons for better debugging.

issue #141 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the target key used for the Direct Messages (Admin) list to fetch the intended events, improving accuracy and completeness of the admin DM feed.

* **Chores**
  * Added detailed warning messages when decrypting or parsing gift-wrapped messages fails. Failures no longer fail silently; users may see contextual warnings in logs while the app continues to operate normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->