### PR TITLE
Add premium percentage to list orders table

### DIFF
--- a/src/parser/orders.rs
+++ b/src/parser/orders.rs
@@ -214,6 +214,9 @@ pub fn print_orders_table(orders_table: Vec<Event>) -> Result<String> {
                 Cell::new("💳 Payment Method")
                     .add_attribute(Attribute::Bold)
                     .set_alignment(CellAlignment::Center),
+                Cell::new("📊 Premium %")
+                    .add_attribute(Attribute::Bold)
+                    .set_alignment(CellAlignment::Center),
                 Cell::new("📅 Created")
                     .add_attribute(Attribute::Bold)
                     .set_alignment(CellAlignment::Center),
@@ -270,6 +273,7 @@ pub fn print_orders_table(orders_table: Vec<Event>) -> Result<String> {
                 },
                 Cell::new(single_order.payment_method.to_string())
                     .set_alignment(CellAlignment::Center),
+                Cell::new(single_order.premium.to_string()).set_alignment(CellAlignment::Center),
                 Cell::new(
                     date.map(|d| d.format("%Y-%m-%d %H:%M").to_string())
                         .unwrap_or_else(|| "Invalid date".to_string()),


### PR DESCRIPTION
Add Premium Column to Orders Table

Summary
Adds the premium percentage column to the listorders command output table for better visibility of order pricing.

Changes
- Added "📊 Premium %" column to orders table in src/parser/orders.rs
- Column displays premium values between "Payment Method" and "Created" columns
- Maintains consistent formatting and alignment with existing table structure

Benefits
- Users can now see premium percentages directly in the orders list without taking additional actions
- Improves order comparison and decision-making when browsing available orders
- Enhances UX by surfacing important pricing information upfront

Testing
- ✅ Code compiles successfully
- ✅ No linter errors introduced
- ✅ Table formatting preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a "Premium %" column to the orders table displaying premium percentage values for each order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->