### PR TITLE
fix(take_order): correct amount label and help text for takebuy/takesell

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,7 +145,7 @@ pub enum Commands {
         /// Invoice string
         #[arg(short, long)]
         invoice: Option<String>,
-        /// Amount of fiat to buy
+        /// Amount of fiat to pay (someone is selling sats, you are buying)
         #[arg(short, long)]
         amount: Option<u32>,
     },
@@ -154,7 +154,7 @@ pub enum Commands {
         /// Order id
         #[arg(short, long)]
         order_id: Uuid,
-        /// Amount of fiat to sell
+        /// Amount of fiat to receive (someone is buying sats, you are selling)
         #[arg(short, long)]
         amount: Option<u32>,
     },

--- a/src/cli/take_order.rs
+++ b/src/cli/take_order.rs
@@ -80,7 +80,7 @@ pub async fn execute_take_order(
     }
     if let Some(amt) = amount {
         let amount_label = match &action {
-            Action::TakeBuy => "Fiat Amount",
+            Action::TakeBuy | Action::TakeSell => "Fiat Amount",
             _ => "Amount (sats)",
         };
         table.add_row(create_emoji_field_row(

--- a/src/cli/take_order.rs
+++ b/src/cli/take_order.rs
@@ -59,7 +59,7 @@ pub async fn execute_take_order(
     amount: Option<u32>,
     ctx: &Context,
 ) -> Result<()> {
-    let action_name = match action {
+    let action_name = match &action {
         Action::TakeBuy => "take buy",
         Action::TakeSell => "take sell",
         _ => return Err(anyhow::anyhow!("Invalid action for take order")),
@@ -78,13 +78,21 @@ pub async fn execute_take_order(
     if let Some(inv) = invoice {
         table.add_row(create_emoji_field_row("⚡ ", "Invoice", inv));
     }
+    
+
+    //new line
     if let Some(amt) = amount {
-        table.add_row(create_emoji_field_row(
-            "💰 ",
-            "Amount (sats)",
-            &amt.to_string(),
-        ));
-    }
+    let amount_label = match &action {
+        Action::TakeBuy => "Fiat Amount",
+        _ => "Amount (sats)",
+    };
+    table.add_row(create_emoji_field_row(
+        "💰 ",
+        amount_label,
+        &amt.to_string(),
+    ));
+}
+//end here
     table.add_row(create_emoji_field_row(
         "🎯 ",
         "Mostro PubKey",

--- a/src/cli/take_order.rs
+++ b/src/cli/take_order.rs
@@ -78,21 +78,17 @@ pub async fn execute_take_order(
     if let Some(inv) = invoice {
         table.add_row(create_emoji_field_row("⚡ ", "Invoice", inv));
     }
-    
-
-    //new line
     if let Some(amt) = amount {
-    let amount_label = match &action {
-        Action::TakeBuy => "Fiat Amount",
-        _ => "Amount (sats)",
-    };
-    table.add_row(create_emoji_field_row(
-        "💰 ",
-        amount_label,
-        &amt.to_string(),
-    ));
-}
-//end here
+        let amount_label = match &action {
+            Action::TakeBuy => "Fiat Amount",
+            _ => "Amount (sats)",
+        };
+        table.add_row(create_emoji_field_row(
+            "💰 ",
+            amount_label,
+            &amt.to_string(),
+        ));
+    }
     table.add_row(create_emoji_field_row(
         "🎯 ",
         "Mostro PubKey",


### PR DESCRIPTION
## Problem
Two related UX issues were found when testing takebuy and takesell commands:

1. The confirmation table for `takebuy` showed `Amount (sats)` but the
   `-a` flag accepts a **fiat amount**, not sats. This was misleading and
   inconsistent with `takesell` which correctly shows the sats amount.

2. The help text for `-a` on both commands was confusing:
   - `takesell -a` said "Amount of fiat to buy" (ambiguous)
   - `takebuy -a` said "Amount of fiat to sell" (ambiguous)

## Changes
- `takebuy` confirmation table now shows `Fiat Amount` instead of `Amount (sats)`
- Fixed `match action` to use `&action` references to avoid moving a
  non-Copy enum before second match
- `takesell -a` help text now reads: "Amount of fiat to pay (someone is selling sats, you are buying)"
- `takebuy -a` help text now reads: "Amount of fiat to receive (someone is buying sats, you are selling)"

## Testing
Tested against staging Mostro pubkey:
- `mostro-cli takebuy -o <order-id> -a 5` confirms label shows `Fiat Amount`
- `mostro-cli takesell -o <order-id> -a 5` confirms label still shows `Amount (sats)`
- `mostro-cli takebuy -h` shows updated help text
- `mostro-cli takesell -h` shows updated help text

## Notes
Help text language matches the Mostro mobile app which uses
"Someone is Buying Sats" for buy orders and "Someone is Selling Sats"
for sell orders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended action/state loss during order processing.
  * Amount field now displays context-aware labels: "Fiat Amount" for buy/sell actions, "Amount (sats)" otherwise.

* **Documentation**
  * Clarified help text for buy and sell commands to explain fiat amount semantics when buying vs selling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->