### PR TITLE
fix(orders): prevent UUID truncation in listorders table

### DIFF
--- a/src/parser/orders.rs
+++ b/src/parser/orders.rs
@@ -286,6 +286,11 @@ pub fn print_orders_table(orders_table: Vec<Event>) -> Result<String> {
 
     table.add_rows(rows);
 
+    // Set minimum width on Order ID column (index 1) to prevent UUID truncation
+    if let Some(col) = table.column_mut(1) {
+        col.set_constraint(ColumnConstraint::Absolute(Width::Fixed(38)));
+    }
+
     Ok(table.to_string())
 }
 


### PR DESCRIPTION
## Problem
Order IDs in the `listorders` table were being truncated and wrapped
across multiple lines, making it impossible to copy and use them in
other commands like `takebuy`, `takesell`, `cancel`, etc.

Example of broken output:

│ ba8b23c0-fbce-4e76-9bf8-37feec1 │
│              54fa1              │


This caused commands to fail with "invalid group length" errors when
users copied the truncated UUID.

## Fix
Added an `Absolute` column constraint (`Width::Fixed(38)`) on the
Order ID column to ensure full UUIDs always display on a single line
regardless of terminal width or payment method column content.

## Testing
Tested with `listorders` (full list) and filtered views:
- `mostro-cli listorders` :  all UUIDs on single line ✅
- `mostro-cli listorders -k buy -c usd`:  all UUIDs on single line ✅
- Copied UUID directly into `takebuy` command:  no more truncation errors ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Order Id column width in order tables for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->