### PR TITLE
feat: bump mostro-core to 0.11.0 and handle anti-abuse bond flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76f4936f520e410ba2abf47113548ae231322209261a9b3a8aefbd10a869082"
+checksum = "2f73dc932127909d84e64a3dd1a5cd0e9b6549fdef3eb6ec02a1de26a71472f9"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.12.23", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = "0.10.0"
+mostro-core = "0.11.0"
 lnurl-rs = { version = "0.9.0", default-features = false, features = ["ureq"] }
 pretty_env_logger = "0.5.0"
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio-rustls"] }

--- a/src/parser/dms.rs
+++ b/src/parser/dms.rs
@@ -78,6 +78,26 @@ fn handle_pay_invoice_display(order: &Option<mostro_core::order::SmallOrder>, in
     println!();
 }
 
+fn handle_pay_bond_invoice_display(order: &Option<mostro_core::order::SmallOrder>, invoice: &str) {
+    print_section_header("🪙 Anti-Abuse Bond Invoice");
+    if let Some(order) = order {
+        if let Some(order_id) = order.id {
+            println!("📋 Order ID: {}", order_id);
+        }
+        print_amount_info(order.amount);
+        print_fiat_code(&order.fiat_code);
+        println!("💵 Fiat Amount: {}", order.fiat_amount);
+    }
+    println!();
+    println!("⚡ LIGHTNING BOND INVOICE TO PAY:");
+    println!("─────────────────────────────────────");
+    println!("{}", invoice);
+    println!("─────────────────────────────────────");
+    println!("💡 Pay this hold invoice to lock your taker bond.");
+    println!("💡 The trade hold invoice will arrive next.");
+    println!();
+}
+
 /// Format payload details for DM table display
 fn format_payload_details(payload: &Payload, action: &Action) -> String {
     match payload {
@@ -113,6 +133,7 @@ fn format_payload_details(payload: &Payload, action: &Action) -> String {
                 Status::Expired => "⏰",
                 Status::SettledHoldInvoice => "💰",
                 Status::InProgress => "🔄",
+                Status::WaitingTakerBond => "🪙",
             };
 
             let kind_emoji = match o.kind.as_ref().unwrap_or(&mostro_core::order::Kind::Sell) {
@@ -486,6 +507,33 @@ pub async fn print_commands_results(message: &MessageKind, ctx: &Context) -> Res
             }
             Ok(())
         }
+        // mostro-core 0.11: anti-abuse bond invoice sent right after a takebuy/takesell.
+        Action::PayBondInvoice => {
+            if let Some(Payload::PaymentRequest(order, invoice, _)) = &message.payload {
+                handle_pay_bond_invoice_display(order, invoice);
+
+                if let Some(order) = order {
+                    if let Some(req_id) = message.request_id {
+                        if let Err(e) = save_order(
+                            order.clone(),
+                            &ctx.trade_keys,
+                            req_id,
+                            ctx.trade_index,
+                            &ctx.pool,
+                        )
+                        .await
+                        {
+                            println!("❌ Failed to save order: {}", e);
+                            return Err(anyhow::anyhow!("Failed to save order: {}", e));
+                        }
+                        print_success_message("Order saved successfully!");
+                    } else {
+                        return Err(anyhow::anyhow!("No request id found in message"));
+                    }
+                }
+            }
+            Ok(())
+        }
         Action::CantDo => {
             println!("❌ Action Cannot Be Completed");
             println!("═══════════════════════════════════════");
@@ -844,6 +892,7 @@ pub async fn print_direct_messages(
         let action_icon = match inner.action {
             Action::NewOrder => "🆕",
             Action::AddInvoice | Action::PayInvoice => "⚡",
+            Action::PayBondInvoice => "🪙",
             Action::FiatSent | Action::FiatSentOk => "💸",
             Action::Release | Action::Released => "🔓",
             Action::Cancel | Action::Canceled => "🚫",

--- a/src/parser/dms.rs
+++ b/src/parser/dms.rs
@@ -509,29 +509,32 @@ pub async fn print_commands_results(message: &MessageKind, ctx: &Context) -> Res
         }
         // mostro-core 0.11: anti-abuse bond invoice sent right after a takebuy/takesell.
         Action::PayBondInvoice => {
-            if let Some(Payload::PaymentRequest(order, invoice, _)) = &message.payload {
-                handle_pay_bond_invoice_display(order, invoice);
-
-                if let Some(order) = order {
-                    if let Some(req_id) = message.request_id {
-                        if let Err(e) = save_order(
-                            order.clone(),
-                            &ctx.trade_keys,
-                            req_id,
-                            ctx.trade_index,
-                            &ctx.pool,
-                        )
-                        .await
-                        {
-                            println!("❌ Failed to save order: {}", e);
-                            return Err(anyhow::anyhow!("Failed to save order: {}", e));
-                        }
-                        print_success_message("Order saved successfully!");
-                    } else {
-                        return Err(anyhow::anyhow!("No request id found in message"));
-                    }
+            let (order, invoice) = match &message.payload {
+                Some(Payload::PaymentRequest(order, invoice, _)) => (order, invoice),
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "PayBondInvoice expected Payload::PaymentRequest, got: {:?}",
+                        other
+                    ));
                 }
-            }
+            };
+            handle_pay_bond_invoice_display(order, invoice);
+            let order = order.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("PayBondInvoice payload is missing the SmallOrder")
+            })?;
+            let req_id = message
+                .request_id
+                .ok_or_else(|| anyhow::anyhow!("No request id found in message"))?;
+            save_order(
+                order.clone(),
+                &ctx.trade_keys,
+                req_id,
+                ctx.trade_index,
+                &ctx.pool,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to save order: {}", e))?;
+            print_success_message("Order saved successfully!");
             Ok(())
         }
         Action::CantDo => {


### PR DESCRIPTION
## Summary

- Bumps `mostro-core` from `0.10.0` to `0.11.0`.
- Handles the new `Action::PayBondInvoice` variant (Mostro → taker bond hold-invoice that lands right after a `TakeBuy` / `TakeSell`) — reuses the `PayInvoice` save flow but renders a dedicated "🪙 Anti-Abuse Bond Invoice" block so the user can tell it apart from the trade hold-invoice that follows.
- Handles the new `Status::WaitingTakerBond` order status in the status-emoji map.

## Motivation

Reproducible on `main` against the current Mostro mainnet daemon:

```
mcli takesell -o 2eb407ea-96f8-4fda-805f-eba71319afcf
...
Warning: could not unwrap gift wrap (event …): Error serializing message
No response received from Mostro
```

`unwrap_message` in `mostro-core 0.10` decrypts the seal cleanly but then fails at `serde_json::from_str::<(Message, Option<String>)>(...)` because the daemon already ships the taker bond response (`Action::PayBondInvoice` introduced in `mostro-core 0.11`). Serde can't deserialize an unknown enum variant → `ServiceError::MessageSerializationError`. The CLI swallowed the event and timed out.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: run `mcli takesell -o <id>` against the current Mostro daemon and confirm the bond invoice prints and the order persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Anti-Abuse Bond Invoice payment flow support with enhanced display formatting
  * Bond invoices now render with dedicated status indicators and visual distinctions
  * Direct messages show a dedicated action icon for bond invoice operations
  * Improved order handling and persistence for bond invoice transactions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-cli/pull/166)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->