### PR TITLE
feat(admin): expose BondResolution payload on adm-settle / adm-cancel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f73dc932127909d84e64a3dd1a5cd0e9b6549fdef3eb6ec02a1de26a71472f9"
+checksum = "0cd16bab24c530f7bc026014ce4810e6d427abf5f4d5a5977c46ef97bd420ef4"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.12.23", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = "0.11.0"
+mostro-core = "0.11.1"
 lnurl-rs = { version = "0.9.0", default-features = false, features = ["ureq"] }
 pretty_env_logger = "0.5.0"
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio-rustls"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -266,12 +266,24 @@ pub enum Commands {
         /// Order id
         #[arg(short, long)]
         order_id: Uuid,
+        /// Slash the seller's bond (anti-abuse-bond Phase 2)
+        #[arg(long, default_value_t = false)]
+        slash_seller: bool,
+        /// Slash the buyer's bond (anti-abuse-bond Phase 2)
+        #[arg(long, default_value_t = false)]
+        slash_buyer: bool,
     },
     /// Settle a seller's hold invoice (only admin)
     AdmSettle {
         /// Order id
         #[arg(short, long)]
         order_id: Uuid,
+        /// Slash the seller's bond (anti-abuse-bond Phase 2)
+        #[arg(long, default_value_t = false)]
+        slash_seller: bool,
+        /// Slash the buyer's bond (anti-abuse-bond Phase 2)
+        #[arg(long, default_value_t = false)]
+        slash_buyer: bool,
     },
     /// Requests open disputes from Mostro pubkey
     ListDisputes {},
@@ -583,8 +595,16 @@ impl Commands {
             // Admin commands
             Commands::ListDisputes {} => execute_list_disputes(ctx).await,
             Commands::AdmAddSolver { npubkey } => execute_admin_add_solver(npubkey, ctx).await,
-            Commands::AdmSettle { order_id } => execute_admin_settle_dispute(order_id, ctx).await,
-            Commands::AdmCancel { order_id } => execute_admin_cancel_dispute(order_id, ctx).await,
+            Commands::AdmSettle {
+                order_id,
+                slash_seller,
+                slash_buyer,
+            } => execute_admin_settle_dispute(order_id, *slash_seller, *slash_buyer, ctx).await,
+            Commands::AdmCancel {
+                order_id,
+                slash_seller,
+                slash_buyer,
+            } => execute_admin_cancel_dispute(order_id, *slash_seller, *slash_buyer, ctx).await,
             Commands::AdmTakeDispute { dispute_id } => execute_take_dispute(dispute_id, ctx).await,
 
             // Simple commands

--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -44,7 +44,12 @@ pub async fn execute_admin_add_solver(npubkey: &str, ctx: &Context) -> Result<()
     Ok(())
 }
 
-pub async fn execute_admin_cancel_dispute(dispute_id: &Uuid, ctx: &Context) -> Result<()> {
+pub async fn execute_admin_cancel_dispute(
+    dispute_id: &Uuid,
+    slash_seller: bool,
+    slash_buyer: bool,
+    ctx: &Context,
+) -> Result<()> {
     println!("👑 Admin Cancel Dispute");
     println!("═══════════════════════════════════════");
     let mut table = create_standard_table();
@@ -54,6 +59,12 @@ pub async fn execute_admin_cancel_dispute(dispute_id: &Uuid, ctx: &Context) -> R
         "Dispute ID",
         &dispute_id.to_string(),
     ));
+    if slash_seller {
+        table.add_row(create_emoji_field_row("⚔️  ", "Slash", "seller bond"));
+    }
+    if slash_buyer {
+        table.add_row(create_emoji_field_row("⚔️  ", "Slash", "buyer bond"));
+    }
     table.add_row(create_emoji_field_row(
         "🎯 ",
         "Mostro PubKey",
@@ -64,9 +75,18 @@ pub async fn execute_admin_cancel_dispute(dispute_id: &Uuid, ctx: &Context) -> R
 
     let _admin_keys = get_admin_keys(ctx)?;
 
+    let payload = if slash_seller || slash_buyer {
+        Some(Payload::BondResolution(BondResolution {
+            slash_seller,
+            slash_buyer,
+        }))
+    } else {
+        None
+    };
+
     // Build admin dispute message
     let take_dispute_message =
-        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminCancel, None)
+        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminCancel, payload)
             .as_json()
             .map_err(|_| anyhow::anyhow!("Failed to serialize message"))?;
 
@@ -77,7 +97,12 @@ pub async fn execute_admin_cancel_dispute(dispute_id: &Uuid, ctx: &Context) -> R
     Ok(())
 }
 
-pub async fn execute_admin_settle_dispute(dispute_id: &Uuid, ctx: &Context) -> Result<()> {
+pub async fn execute_admin_settle_dispute(
+    dispute_id: &Uuid,
+    slash_seller: bool,
+    slash_buyer: bool,
+    ctx: &Context,
+) -> Result<()> {
     println!("👑 Admin Settle Dispute");
     println!("═══════════════════════════════════════");
     let mut table = create_standard_table();
@@ -87,6 +112,12 @@ pub async fn execute_admin_settle_dispute(dispute_id: &Uuid, ctx: &Context) -> R
         "Dispute ID",
         &dispute_id.to_string(),
     ));
+    if slash_seller {
+        table.add_row(create_emoji_field_row("⚔️  ", "Slash", "seller bond"));
+    }
+    if slash_buyer {
+        table.add_row(create_emoji_field_row("⚔️  ", "Slash", "buyer bond"));
+    }
     table.add_row(create_emoji_field_row(
         "🎯 ",
         "Mostro PubKey",
@@ -97,9 +128,18 @@ pub async fn execute_admin_settle_dispute(dispute_id: &Uuid, ctx: &Context) -> R
 
     let _admin_keys = get_admin_keys(ctx)?;
 
+    let payload = if slash_seller || slash_buyer {
+        Some(Payload::BondResolution(BondResolution {
+            slash_seller,
+            slash_buyer,
+        }))
+    } else {
+        None
+    };
+
     // Build admin dispute message
     let take_dispute_message =
-        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminSettle, None)
+        Message::new_dispute(Some(*dispute_id), None, None, Action::AdminSettle, payload)
             .as_json()
             .map_err(|_| anyhow::anyhow!("Failed to serialize message"))?;
     admin_send_dm(ctx, take_dispute_message).await?;


### PR DESCRIPTION
## Summary

Adds `--slash-seller` and `--slash-buyer` flags to the `adm-settle` and `adm-cancel` admin subcommands so solvers (and QA) can exercise the anti-abuse-bond Phase 2 flow shipped in the daemon. When either flag is set, the outgoing dispute message now carries `Payload::BondResolution { slash_seller, slash_buyer }`; with no flags, the payload stays `None`, preserving Phase 1 behaviour. The selected slash decisions are surfaced as extra rows in the action table so the operator can see what they're about to send.

Spec / context: MostroP2P/mostro#737 (`feat/bond-phase-2-slash`, daemon §7.2 wire format).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build`
- [x] `cargo test` (no regressions; no admin-command tests existed and none added)
- [ ] Smoke-test against a Phase 2 daemon (`>= 0.17.3`):
  - `mostro-cli admsettle --orderid <uuid>` → payload `null`
  - `mostro-cli admsettle --orderid <uuid> --slashbuyer` → `{ slash_seller: false, slash_buyer: true }`
  - `mostro-cli admsettle --orderid <uuid> --slashseller --slashbuyer` → both true
  - `mostro-cli admcancel --orderid <uuid> --slashseller` → `{ slash_seller: true, slash_buyer: false }`
  - Verify rows appear in the daemon `bonds` table / `mostrod` logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--slash-seller` and `--slash-buyer` boolean flags to admin settle and cancel dispute commands. These flags enable fine-grained control over bond resolution during dispute closure operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-cli/pull/167)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->