### PR TITLE
fix(admin-disputes): confirm Mostro reply before reporting settle/cancel success

### DIFF
--- a/src/cli/take_dispute.rs
+++ b/src/cli/take_dispute.rs
@@ -73,7 +73,7 @@ pub async fn execute_admin_cancel_dispute(
     println!("{table}");
     println!("💡 Canceling dispute...\n");
 
-    let _admin_keys = get_admin_keys(ctx)?;
+    let admin_keys = get_admin_keys(ctx)?;
 
     let payload = if slash_seller || slash_buyer {
         Some(Payload::BondResolution(BondResolution {
@@ -84,17 +84,56 @@ pub async fn execute_admin_cancel_dispute(
         None
     };
 
-    // Build admin dispute message
-    let take_dispute_message =
+    let admin_cancel_message =
         Message::new_dispute(Some(*dispute_id), None, None, Action::AdminCancel, payload)
             .as_json()
             .map_err(|_| anyhow::anyhow!("Failed to serialize message"))?;
 
-    admin_send_dm(ctx, take_dispute_message).await?;
+    // Send the message and await Mostro's reply so the success message is
+    // only printed when the cancel actually went through. Admin identity
+    // binds via the seal/rumor signers — the admin role doesn't rotate
+    // trade keys, so `admin_keys` signs both layers.
+    let sent_message = send_dm(
+        &ctx.client,
+        admin_keys,
+        admin_keys,
+        &ctx.mostro_pubkey,
+        admin_cancel_message,
+        None,
+        false,
+    );
 
-    println!("✅ Dispute canceled successfully!");
+    let recv_event = wait_for_dm(ctx, Some(admin_keys), sent_message)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to receive response from Mostro for AdminCancel: {e}. \
+                 The operation may not have completed; verify the order id exists and check backend logs."
+            )
+        })?;
 
-    Ok(())
+    let messages = parse_dm_events(recv_event, admin_keys, None).await;
+    let (message, _, sender_pubkey) = messages
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("No response received from Mostro"))?;
+
+    if *sender_pubkey != ctx.mostro_pubkey {
+        return Err(anyhow::anyhow!("Received response from wrong sender"));
+    }
+
+    let message_kind = message.get_inner_message_kind();
+    if message_kind.action == Action::AdminCanceled {
+        println!("✅ Dispute canceled successfully!");
+        Ok(())
+    } else if message_kind.action == Action::CantDo {
+        print_commands_results(message_kind, ctx).await
+    } else {
+        Err(anyhow::anyhow!(
+            "Received response with mismatched action. Expected: {:?}, Got: {:?}",
+            Action::AdminCanceled,
+            message_kind.action
+        ))
+    }
 }
 
 pub async fn execute_admin_settle_dispute(
@@ -126,7 +165,7 @@ pub async fn execute_admin_settle_dispute(
     println!("{table}");
     println!("💡 Settling dispute...\n");
 
-    let _admin_keys = get_admin_keys(ctx)?;
+    let admin_keys = get_admin_keys(ctx)?;
 
     let payload = if slash_seller || slash_buyer {
         Some(Payload::BondResolution(BondResolution {
@@ -137,15 +176,56 @@ pub async fn execute_admin_settle_dispute(
         None
     };
 
-    // Build admin dispute message
-    let take_dispute_message =
+    let admin_settle_message =
         Message::new_dispute(Some(*dispute_id), None, None, Action::AdminSettle, payload)
             .as_json()
             .map_err(|_| anyhow::anyhow!("Failed to serialize message"))?;
-    admin_send_dm(ctx, take_dispute_message).await?;
 
-    println!("✅ Dispute settled successfully!");
-    Ok(())
+    // Send the message and await Mostro's reply so the success message is
+    // only printed when the settle actually went through. Admin identity
+    // binds via the seal/rumor signers — the admin role doesn't rotate
+    // trade keys, so `admin_keys` signs both layers.
+    let sent_message = send_dm(
+        &ctx.client,
+        admin_keys,
+        admin_keys,
+        &ctx.mostro_pubkey,
+        admin_settle_message,
+        None,
+        false,
+    );
+
+    let recv_event = wait_for_dm(ctx, Some(admin_keys), sent_message)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to receive response from Mostro for AdminSettle: {e}. \
+                 The operation may not have completed; verify the order id exists and check backend logs."
+            )
+        })?;
+
+    let messages = parse_dm_events(recv_event, admin_keys, None).await;
+    let (message, _, sender_pubkey) = messages
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("No response received from Mostro"))?;
+
+    if *sender_pubkey != ctx.mostro_pubkey {
+        return Err(anyhow::anyhow!("Received response from wrong sender"));
+    }
+
+    let message_kind = message.get_inner_message_kind();
+    if message_kind.action == Action::AdminSettled {
+        println!("✅ Dispute settled successfully!");
+        Ok(())
+    } else if message_kind.action == Action::CantDo {
+        print_commands_results(message_kind, ctx).await
+    } else {
+        Err(anyhow::anyhow!(
+            "Received response with mismatched action. Expected: {:?}, Got: {:?}",
+            Action::AdminSettled,
+            message_kind.action
+        ))
+    }
 }
 
 pub async fn execute_take_dispute(dispute_id: &Uuid, ctx: &Context) -> Result<()> {

--- a/src/parser/dms.rs
+++ b/src/parser/dms.rs
@@ -653,6 +653,9 @@ pub async fn print_commands_results(message: &MessageKind, ctx: &Context) -> Res
                     println!("📊 Please use a valid currency");
                     Err(anyhow::anyhow!("Invalid currency"))
                 }
+                Some(Payload::CantDo(Some(CantDoReason::NotFound))) => Err(anyhow::anyhow!(
+                    "Resource not found. Verify the order or dispute id exists."
+                )),
                 _ => {
                     println!("❓ Unknown Error");
                     println!("💡 An unknown error occurred");


### PR DESCRIPTION
Closes #170

## Summary

`execute_admin_settle_dispute` and `execute_admin_cancel_dispute` used `admin_send_dm` (fire-and-forget) and then printed
`Dispute settled/canceled successfully!` unconditionally, regardless of whether the daemon accepted the request. This caused the CLI to report success for operations that never happened — including the case reported in #170, where a non-existent `order_id` produced a backend log error but a green tick on the CLI.

Both handlers now follow the same pattern as `execute_take_dispute`: send the message, wait for Mostro's reply, validate the sender, and only print the success message when the daemon replies with the matching action (`AdminSettled` / `AdminCanceled`).

## Changes

- `execute_admin_settle_dispute`: replace `admin_send_dm` with the `send_dm` + `wait_for_dm` + `parse_dm_events` flow. Accept only `Action::AdminSettled` as success; route `Action::CantDo` through `print_commands_results` so the backend reason is surfaced to the operator; bail with an explicit error on mismatched actions.
- `execute_admin_cancel_dispute`: same treatment, accepting `Action::AdminCanceled` as success.
- Wrap `wait_for_dm` errors (notably `WaitForDmTimeout`) with context guiding the operator to verify the order id and check backend logs.

## Known limitation

When the `order_id` does not exist, the daemon currently logs the `InvalidOrderId` error locally but does not enqueue a `CantDo` DM back to the sender. With this PR the CLI will surface that case as a timeout error rather than false success — a correct, actionable result. A complete fix requires the daemon to reply with `CantDo(NotFound)`; that is being tracked in a separate issue against the `mostro` repo.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin dispute cancellation operations now properly validate completion status before returning.
  * Admin dispute settlement operations now properly validate completion status before returning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-cli/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->