### PR TITLE
fix(pow): filter wait_for_dm notifications so PoW detection actually fires

### DIFF
--- a/docs/pow_error_handling.md
+++ b/docs/pow_error_handling.md
@@ -170,6 +170,26 @@ Add an `&Context` parameter? Look at the signature today —
 passed. We just need to grant the helper access to `ctx.client` and
 `ctx.mostro_pubkey` (already does).
 
+#### 4.3.1 Notification leak from the concurrent probe
+
+`client.notifications()` is a **global** broadcast: every event seen by
+any active subscription or fetch lands on the same channel
+(`nostr-relay-pool::relay::inner::send_notification`). The spawned PoW
+probe issues its own subscription for kind‑38385 events to read the
+required difficulty — those info events show up on the same broadcast
+the wait loop is consuming. Without an application‑side filter, the
+loop returns the info event as the "first event" and short‑circuits the
+wait before mostrod has even had a chance to (silently) drop the
+request, surfacing further downstream as `"No response received from
+Mostro"`.
+
+Fix: the notification loop mirrors the subscription filter explicitly —
+only `Kind::GiftWrap` events whose `p` tags contain `trade_keys.public_key()`
+escape the loop. Anything else (kind‑38385 info, replaceable
+status events, gift wraps for other trade keys) is dropped on the floor
+so the wait properly reaches its timeout, where the PoW probe result
+escalates to `PowRequirementUnmet`.
+
 ### 4.4 `add_bond_invoice` interplay
 
 `add_bond_invoice` treats `WaitForDmTimeout` as the happy path (Mostro pays

--- a/src/util/messaging.rs
+++ b/src/util/messaging.rs
@@ -317,11 +317,12 @@ where
     F: std::future::Future<Output = Result<()>> + Send,
 {
     let trade_keys = order_trade_keys.unwrap_or(&ctx.trade_keys);
+    let trade_pubkey = trade_keys.public_key();
     let mut notifications = ctx.client.notifications();
     let opts =
         SubscribeAutoCloseOptions::default().exit_policy(ReqExitPolicy::WaitForEventsAfterEOSE(1));
     let subscription = Filter::new()
-        .pubkey(trade_keys.public_key())
+        .pubkey(trade_pubkey)
         .kind(nostr_sdk::Kind::GiftWrap)
         .limit(0);
     ctx.client.subscribe(subscription, Some(opts)).await?;
@@ -340,11 +341,27 @@ where
         ctx.mostro_pubkey,
     ));
 
-    // Wait for the DM or gift wrap event
+    // Wait for the DM or gift wrap event.
+    //
+    // `client.notifications()` is the **global** broadcast for every event
+    // any active subscription / fetch sees — including the kind-38385 info
+    // event coming back from the spawned PoW probe above. Without an
+    // application-side filter, that info event would race ahead of the real
+    // reply and short-circuit the wait, surfacing as "No response received
+    // from Mostro" further downstream. So mirror the subscription filter
+    // here and only accept GiftWraps tagged to our trade key.
     let waited = tokio::time::timeout(super::events::FETCH_EVENTS_TIMEOUT, async move {
         loop {
             match notifications.recv().await {
-                Ok(RelayPoolNotification::Event { event, .. }) => return Ok(*event),
+                Ok(RelayPoolNotification::Event { event, .. }) => {
+                    if event.kind != nostr_sdk::Kind::GiftWrap {
+                        continue;
+                    }
+                    if !event.tags.public_keys().any(|pk| *pk == trade_pubkey) {
+                        continue;
+                    }
+                    return Ok(*event);
+                }
                 Ok(_) => continue,
                 Err(e) => {
                     return Err(anyhow::anyhow!("Error receiving notification: {:?}", e));


### PR DESCRIPTION
## Summary

Follow-up to #173 — fixes a regression I introduced with the concurrent PoW probe.

When the user runs e.g. `mostro-cli neworder ...` against a PoW-enabled `mostrod` without setting `POW`, they see `No response received from Mostro` instead of the `PowRequirementUnmet` error #173 was supposed to surface. Root cause:

- `client.notifications()` is a **global** broadcast — `nostr-relay-pool::relay::inner::send_notification` fans every event from every active subscription/fetch onto it.
- The PoW probe `tokio::spawn(fetch_required_pow_with(...))` runs a kind-38385 fetch concurrently with the wait. Those info events flow through the same broadcast that `wait_for_dm`'s loop is consuming.
- The loop's `notifications.recv().await` returns the kind-38385 info event as the "first event" — long before `mostrod` has had a chance to (silently) drop our request. The wait never times out, the PoW probe result is never consulted, and `print_dm_events` later errors with `No response received from Mostro`.

Fix: mirror the subscription filter inside the notification loop. Only accept `Kind::GiftWrap` events whose `p` tags include our trade key. Everything else (kind-38385 info, unrelated gift wraps, status events) is dropped on the floor, so the wait reaches its `FETCH_EVENTS_TIMEOUT` cleanly and the existing `PowRequirementUnmet` escalation in the timeout branch fires as designed.

Reported by @grunch after merging #173.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (10/10 unit + integration tests green)
- [ ] Manual E2E against a PoW-enabled local `mostrod`:
  - `POW=0 mostro-cli neworder …` → `PowRequirementUnmet` (not `No response received from Mostro`)
  - `POW=<required> mostro-cli neworder …` → normal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification filtering in direct message reception to prevent processing unintended events from the broadcast stream, improving message delivery reliability.

* **Documentation**
  * Enhanced documentation with clarification of notification subscription filtering requirements and error handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-cli/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->