### PR TITLE
chore: bump mostro-core to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d763fddd85d86033f78dacadb8b75041100af7dae4d50e5bea9dc91fc1a1d24c"
+checksum = "30391197a9de16ce45b7ee5a92d5b3f74c3d12da4d13d442aff00c93c2424038"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.12.23", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = "0.13.0"
+mostro-core = "0.14.1"
 lnurl-rs = { version = "0.9.0", default-features = false, features = ["ureq"] }
 pretty_env_logger = "0.5.0"
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio-rustls"] }

--- a/src/util/messaging.rs
+++ b/src/util/messaging.rs
@@ -643,6 +643,9 @@ mod tests {
     // our WrapOptions knobs (signed, pow) reach the outer event.
 
     #[test]
+    // Transport::GiftWrap is deprecated upstream (mostro/#786) but the CLI
+    // keeps the v1 fallback until mostrod v0.19.0 removes the path.
+    #[allow(deprecated)]
     fn transport_from_str_maps_to_event_kind() {
         // The CLI resolves `TRANSPORT` via Transport::from_str and subscribes
         // on `event_kind()`. Lock down the mapping the receive/send paths rely


### PR DESCRIPTION
## Summary
- Bump `mostro-core` from **0.13.0** to **0.14.1** (crates.io), aligning the CLI with mostrod v0.18.0 which already ships 0.14.1.
- Staying on 0.13.0 meant any incoming message carrying an action added in 0.14.x (e.g. the Cashu escrow actions `AddCashuEscrow`, `CashuEscrowLocked`, `CashuPmSignature`) failed deserialization and was **silently dropped** — the exact migration hazard the protocol spec warns about in `pay_bond_invoice.md`.
- `Transport::GiftWrap` is now deprecated upstream ([mostro#786](https://github.com/MostroP2P/mostro/issues/786)). The CLI intentionally keeps it as the v1 fallback until mostrod v0.19.0 removes the path, so the single test-side use gets a scoped `#[allow(deprecated)]` with a note.

No API changes were needed: the whole test suite and clippy pass clean against 0.14.1.

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo test --release` — all suites green (~100 tests)
- [x] `cargo clippy --release --all-targets` — no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the underlying core component to improve compatibility and reliability.
  * Preserved support for the legacy gift-wrap transport behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->